### PR TITLE
Refactor backend to use main FastAPI app with MySQL-backed Notion router

### DIFF
--- a/backend/init/init.sql
+++ b/backend/init/init.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS notion_tokens (
+    workspace_id VARCHAR(255) PRIMARY KEY,
+    bot_id VARCHAR(255) NOT NULL,
+    access_token TEXT NOT NULL,
+    refresh_token TEXT NULL,
+    token_type VARCHAR(50) NULL,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB
+  DEFAULT CHARSET = utf8mb4
+  COLLATE = utf8mb4_unicode_ci;

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,25 +1,81 @@
-from fastapi import FastAPI, HTTPException, Depends, Request
+from typing import Optional
 
+from fastapi import Depends, FastAPI, Query
+from sqlalchemy.orm import Session
 
+from notions import (
+    PagesResponse,
+    api_refresh_token,
+    get_page_content,
+    get_workspace_id_dep,
+    list_my_pages,
+    login,
+    oauth_callback,
+)
+from utils.db import get_db
 
 
 # swagger 페이지 소개
-SWAGGER_HEADERS = {                                                             
-    "version": "1.0.0",                                                        
-    "description": "## 관리페이지에 오신것을 환영합니다 \n - API를 사용해 데이터를 전송할 수 있습니다. \n - 무분별한 사용은 하지 말아주세요 \n - 관리자 번호: 010-1234-5678", 
-    "contact": {                                                                  
-       "name": "Arcana",                                                       
-       "url": "https://arcana.example.com"                                 
+SWAGGER_HEADERS = {
+    "version": "1.0.0",
+    "description": "## 관리페이지에 오신것을 환영합니다 \n - API를 사용해 데이터를 전송할 수 있습니다. \n - 무분별한 사용은 하지 말아주세요 \n - 관리자 번호: 010-1234-5678",
+    "contact": {
+        "name": "Arcana",
+        "url": "https://arcana.example.com",
     },
 }
 
-# FastAPI 초기화(CORS,Lifespan) 
-app = FastAPI(                                                                  
-    title="SaladBot Recommendation API",                                         
-    **SWAGGER_HEADERS                                                           
+# FastAPI 초기화(CORS,Lifespan)
+app = FastAPI(
+    title="SaladBot Recommendation API",
+    **SWAGGER_HEADERS,
 )
 
+# Notion 관련 엔드포인트
+
+
+@app.get("/login")
+async def login_route():
+    return await login()
+
+
+@app.get("/oauth/callback")
+async def oauth_callback_route(
+    code: Optional[str] = None,
+    state: Optional[str] = None,
+    db: Session = Depends(get_db),
+):
+    return await oauth_callback(code, state, db)
+
+
+@app.get("/me/pages", response_model=PagesResponse)
+async def list_my_pages_route(
+    full: bool = Query(False, description="True면 각 페이지의 콘텐츠 트리까지 포함(부하 큼)"),
+    limit: Optional[int] = Query(None, ge=1, le=1000, description="가져올 최대 페이지 수(없으면 모두)"),
+    workspace_id: str = Depends(get_workspace_id_dep),
+    db: Session = Depends(get_db),
+):
+    return await list_my_pages(full, limit, workspace_id, db)
+
+
+@app.get("/me/pages/{page_id}/content")
+async def get_page_content_route(
+    page_id: str,
+    workspace_id: str = Depends(get_workspace_id_dep),
+    db: Session = Depends(get_db),
+):
+    return await get_page_content(page_id, workspace_id, db)
+
+
+@app.post("/me/token/refresh")
+async def api_refresh_token_route(
+    workspace_id: str = Depends(get_workspace_id_dep),
+    db: Session = Depends(get_db),
+):
+    return await api_refresh_token(workspace_id, db)
+
+
 # 헬스 체크
-@app.get("/api/health")                                                          
-def health():                                                                   
-    return {"status": "ok"}                                                    
+@app.get("/api/health")
+def health():
+    return {"status": "ok"}

--- a/backend/notions/__init__.py
+++ b/backend/notions/__init__.py
@@ -1,0 +1,21 @@
+"""Notion 관련 헬퍼 함수를 노출합니다."""
+
+from .notion import (
+    PagesResponse,
+    api_refresh_token,
+    get_page_content,
+    get_workspace_id_dep,
+    list_my_pages,
+    login,
+    oauth_callback,
+)
+
+__all__ = [
+    "PagesResponse",
+    "api_refresh_token",
+    "get_page_content",
+    "get_workspace_id_dep",
+    "list_my_pages",
+    "login",
+    "oauth_callback",
+]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - "3306:3306"
     volumes:
       - mysql-data:/var/lib/mysql
+      - ./backend/init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-p${MYSQL_ROOT_PASSWORD}"]
       interval: 5s


### PR DESCRIPTION
FastAPI 애플리케이션을 노출하고 backend/main.pyNotion 경로를 등록합니다.
APIRouter 대신 재사용 가능한 도우미 함수를 제공하고 이를 패키지에서 내보내도록 Notion 통합을 리팩토링합니다.
Notion 토큰 테이블에 대한 MySQL 초기화 스크립트를 추가하고 docker-compose에 마운트합니다.