### PR TITLE
Add organization signup flow and workspace creation

### DIFF
--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,10 @@
+"""ORM 모델 패키지."""
+
+from .entities import Membership, Organization, Workspace, WorkspaceType
+
+__all__ = [
+    "Membership",
+    "Organization",
+    "Workspace",
+    "WorkspaceType",
+]

--- a/backend/models/entities.py
+++ b/backend/models/entities.py
@@ -1,0 +1,52 @@
+"""SQLAlchemy ORM models shared across backend modules."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from enum import Enum
+
+from sqlalchemy import BigInteger, Column, DateTime, String
+
+from utils.db import Base
+
+
+class WorkspaceType(str, Enum):
+    """분리된 워크스페이스 유형 정의."""
+
+    personal = "personal"
+    organization = "organization"
+
+
+class Workspace(Base):
+    """워크스페이스 메타데이터."""
+
+    __tablename__ = "workspaces"
+
+    idx = Column(BigInteger, primary_key=True, autoincrement=True)
+    type = Column(String(20), nullable=False)
+    name = Column(String(200), nullable=False)
+    owner_user_idx = Column(BigInteger, nullable=True)
+    organization_idx = Column(BigInteger, nullable=True)
+    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class Organization(Base):
+    """조직 엔터티."""
+
+    __tablename__ = "organizations"
+
+    idx = Column(BigInteger, primary_key=True, autoincrement=True)
+    name = Column(String(255), nullable=False)
+    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class Membership(Base):
+    """조직-사용자 Membership 관계."""
+
+    __tablename__ = "memberships"
+
+    idx = Column(BigInteger, primary_key=True, autoincrement=True)
+    organization_idx = Column(BigInteger, nullable=False)
+    user_idx = Column(BigInteger, nullable=False)
+    role = Column(String(50), nullable=False, default="member")
+    created = Column(DateTime, nullable=False, default=datetime.utcnow)

--- a/backend/notions/notion.py
+++ b/backend/notions/notion.py
@@ -18,8 +18,6 @@ from notion_client.errors import APIResponseError
 from pydantic import BaseModel
 from sqlalchemy import Column, DateTime, String, Text, BigInteger, JSON, select
 from sqlalchemy.orm import Session
-from enum import Enum as PyEnum
-
 from utils.db import Base
 
 # -----------------------
@@ -72,19 +70,6 @@ class NotionOauthCredentials(Base):
     created               = Column(DateTime, nullable=False, default=lambda: datetime.utcnow())
     updated               = Column(DateTime, nullable=False, default=lambda: datetime.utcnow())
     provider_payload      = Column(JSON, nullable=True)
-
-class WorkspaceType(PyEnum):
-    personal = "personal"
-    organization = "organization"
-
-class Workspace(Base):
-    __tablename__ = "workspaces"
-    idx = Column(BigInteger, primary_key=True, autoincrement=True)
-    type = Column(String(20), nullable=False)  # 'personal' / 'organization'
-    name = Column(String(200), nullable=False)
-    owner_user_idx = Column(BigInteger, nullable=True)      # personal일 때만
-    organization_idx = Column(BigInteger, nullable=True)    # organization일 때만
-    created = Column(DateTime, nullable=False, default=datetime.utcnow)
 
 class DataSource(Base):
     __tablename__ = "data_sources"

--- a/backend/schema/users.py
+++ b/backend/schema/users.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, EmailStr, StringConstraints, ConfigDict
 IdStr = Annotated[str, StringConstraints(strip_whitespace=True,max_length=255)]
 PasswordStr = Annotated[str, StringConstraints(max_length=128)]
 NicknameStr = Annotated[str, StringConstraints(strip_whitespace=True, max_length=100)]
+WorkspaceNameStr = Annotated[str, StringConstraints(strip_whitespace=True, max_length=200)]
 
 class RegisterRequest(BaseModel):
     """회원 가입 시 클라이언트가 전달하는 필수 정보를 검증한다."""
@@ -16,6 +17,9 @@ class RegisterRequest(BaseModel):
     email: EmailStr
     password: PasswordStr
     nickname: NicknameStr | None = None
+    type: Literal["personal", "organization"] = "personal"
+    organization_name: WorkspaceNameStr | None = None
+    workspace_name: WorkspaceNameStr | None = None
 
 class LoginRequest(BaseModel):
     """로그인 요청으로 전달되는 아이디와 비밀번호 형식을 검증한다."""


### PR DESCRIPTION
## Summary
- add shared ORM models for workspaces, organizations, and memberships
- extend the registration schema and logic to create organization memberships and workspaces based on account type
- remove the duplicate workspace ORM definition from the Notion integration

## Testing
- python -m compileall backend/routers/users.py backend/schema/users.py backend/models/entities.py

------
https://chatgpt.com/codex/tasks/task_e_68de3d2215f8832ab096710c9fda9e2e