### PR TITLE
Refactor token user lookup helper

### DIFF
--- a/backend/routers/notion.py
+++ b/backend/routers/notion.py
@@ -1,12 +1,144 @@
-"""Notion OAuth 및 페이지 조회 라우터."""
+"""Notion 연동 관련 FastAPI 라우터."""
 
 from __future__ import annotations
 
-from typing import Optional
+from typing import Tuple
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Header, HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from models import (
+    DataSource,
+    Membership,
+    NotionOauthCredentials,
+    User,
+    Workspace,
+    WorkspaceType,
+)
+from utils.auth import AuthorizationError, InvalidTokenError, get_user_from_token
 from utils.db import get_db
 
-router = APIRouter(tags=["notion"])
+
+router = APIRouter(prefix="/notion", tags=["notion"])
+
+
+def _resolve_workspace(db: Session, user: User) -> Workspace:
+    try:
+        workspace_type = WorkspaceType(user.type)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="알 수 없는 워크스페이스 유형입니다.",
+        ) from exc
+
+    if workspace_type is WorkspaceType.personal:
+        workspace = db.scalar(
+            select(Workspace).where(
+                Workspace.type == WorkspaceType.personal.value,
+                Workspace.owner_user_idx == user.idx,
+            )
+        )
+    else:
+        membership = db.scalar(
+            select(Membership)
+            .where(Membership.user_idx == user.idx)
+            .order_by(Membership.idx)
+            .limit(1)
+        )
+        workspace = None
+        if membership:
+            workspace = db.scalar(
+                select(Workspace).where(
+                    Workspace.type == WorkspaceType.organization.value,
+                    Workspace.organization_idx == membership.organization_idx,
+                )
+            )
+
+    if not workspace:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="사용자 워크스페이스를 찾을 수 없습니다.",
+        )
+
+    return workspace
+
+
+def _ensure_notion_resources(
+    db: Session, *, user: User, workspace: Workspace
+) -> Tuple[DataSource, NotionOauthCredentials]:
+    data_source = db.scalar(
+        select(DataSource).where(
+            DataSource.workspace_idx == workspace.idx,
+            DataSource.type == "notion",
+        )
+    )
+
+    if not data_source:
+        data_source = DataSource(
+            workspace_idx=workspace.idx,
+            type="notion",
+            name="Notion",
+            status="disconnected",
+        )
+        db.add(data_source)
+        db.flush()
+
+    credential = db.scalar(
+        select(NotionOauthCredentials).where(
+            NotionOauthCredentials.data_source_idx == data_source.idx,
+            NotionOauthCredentials.user_idx == user.idx,
+        )
+    )
+
+    if not credential:
+        credential = NotionOauthCredentials(
+            user_idx=user.idx,
+            data_source_idx=data_source.idx,
+            provider="notion",
+            bot_id=f"pending-{data_source.idx}-{user.idx}",
+            token_type="bearer",
+            access_token="",
+        )
+        db.add(credential)
+        db.flush()
+
+    db.commit()
+    db.refresh(data_source)
+    db.refresh(credential)
+    return data_source, credential
+
+
+@router.post(
+    "/connect/ensure",
+    status_code=status.HTTP_200_OK,
+    summary="Notion 연동을 위한 데이터 소스를 준비합니다.",
+)
+def ensure_notion_connection(
+    *,
+    db: Session = Depends(get_db),
+    authorization: str = Header(..., alias="Authorization"),
+):
+    """로그인한 사용자의 워크스페이스에 Notion 데이터 소스와 자격 증명을 보장한다."""
+
+    try:
+        user = get_user_from_token(db, authorization)
+    except AuthorizationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+        ) from exc
+    except InvalidTokenError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=str(exc),
+        ) from exc
+    workspace = _resolve_workspace(db, user)
+    data_source, credential = _ensure_notion_resources(db, user=user, workspace=workspace)
+
+    return {
+        "workspace_idx": workspace.idx,
+        "data_source_idx": data_source.idx,
+        "credential_idx": credential.idx,
+        "data_source_status": data_source.status,
+    }

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -12,7 +12,13 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from schema.users import LoginRequest, LoginResponse, RegisterRequest
-from models import Membership, Organization, Workspace, WorkspaceType, User
+from models import (
+    Membership,
+    Organization,
+    Workspace,
+    WorkspaceType,
+    User,
+)
 from utils.auth import create_access_token, create_refresh_token
 from utils.db import Base, get_db
 

--- a/backend/utils/auth.py
+++ b/backend/utils/auth.py
@@ -6,7 +6,13 @@ import hmac
 import json
 import os
 from datetime import datetime, timedelta, timezone
-from typing import Any, Dict
+from typing import TYPE_CHECKING, Any, Dict
+
+from sqlalchemy import select
+
+if TYPE_CHECKING:  # pragma: no cover - 순환 참조 방지용 타입 힌트
+    from sqlalchemy.orm import Session
+    from models import User
 
 
 def _get_env_int(name: str) -> int:
@@ -30,6 +36,11 @@ REFRESH_TOKEN_EXPIRE_DAYS = _get_env_int("JWT_REFRESH_TOKEN_EXPIRE_DAYS")
 
 def _b64url_encode(data: bytes) -> str:
     return base64.urlsafe_b64encode(data).decode("utf-8").rstrip("=")
+
+
+def _b64url_decode(segment: str) -> bytes:
+    padding = "=" * (-len(segment) % 4)
+    return base64.urlsafe_b64decode(segment + padding)
 
 
 def _create_token(*, subject: str, expires_delta: timedelta, token_type: str) -> str:
@@ -74,3 +85,84 @@ def create_refresh_token(*, subject: str) -> str:
         expires_delta=timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS),
         token_type="refresh",
     )
+
+
+class InvalidTokenError(Exception):
+    """JWT 디코딩 및 검증 과정에서 발생한 오류."""
+
+
+class AuthorizationError(Exception):
+    """Authorization 헤더 처리 중 발생한 오류."""
+
+
+def _decode_token(token: str) -> Dict[str, Any]:
+    try:
+        header_segment, payload_segment, signature_segment = token.split(".")
+    except ValueError as exc:
+        raise InvalidTokenError("토큰 형식이 올바르지 않습니다.") from exc
+
+    signing_input = f"{header_segment}.{payload_segment}".encode("utf-8")
+    try:
+        signature = _b64url_decode(signature_segment)
+    except Exception as exc:  # noqa: BLE001 - base64 예외 메시지를 감추기 위해
+        raise InvalidTokenError("토큰 서명 디코딩에 실패했습니다.") from exc
+
+    expected_signature = hmac.new(
+        JWT_SECRET_KEY.encode("utf-8"),
+        signing_input,
+        hashlib.sha256,
+    ).digest()
+
+    if not hmac.compare_digest(signature, expected_signature):
+        raise InvalidTokenError("토큰 서명이 유효하지 않습니다.")
+
+    try:
+        payload_raw = _b64url_decode(payload_segment)
+        payload: Dict[str, Any] = json.loads(payload_raw)
+    except Exception as exc:  # noqa: BLE001 - JSON 에러 상세 노출 방지
+        raise InvalidTokenError("토큰 페이로드를 읽을 수 없습니다.") from exc
+
+    exp = payload.get("exp")
+    if exp is not None:
+        expire_at = datetime.fromtimestamp(int(exp), tz=timezone.utc)
+        if expire_at < datetime.now(tz=timezone.utc):
+            raise InvalidTokenError("토큰이 만료되었습니다.")
+
+    return payload
+
+
+def decode_access_token(token: str) -> Dict[str, Any]:
+    """액세스 토큰을 검증하고 페이로드를 반환합니다."""
+
+    payload = _decode_token(token)
+    token_type = payload.get("type")
+    if token_type != "access":
+        raise InvalidTokenError("액세스 토큰이 필요합니다.")
+    return payload
+
+
+def get_user_from_token(db: "Session", authorization: str) -> "User":
+    """Authorization 헤더에서 사용자 객체를 조회합니다."""
+
+    from models import User  # 지연 로딩으로 순환 참조 방지
+
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token:
+        raise AuthorizationError("Bearer 토큰이 필요합니다.")
+
+    payload = decode_access_token(token)
+
+    subject = payload.get("sub")
+    if subject is None:
+        raise AuthorizationError("토큰에 사용자 정보가 없습니다.")
+
+    try:
+        user_idx = int(subject)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - 방어적 코드
+        raise AuthorizationError("유효하지 않은 사용자 식별자입니다.") from exc
+
+    user = db.scalar(select(User).where(User.idx == user_idx))
+    if not user:
+        raise AuthorizationError("사용자를 찾을 수 없습니다.")
+
+    return user


### PR DESCRIPTION
## Summary
- move the token-to-user lookup helper into `utils.auth` so it can be reused outside the Notion router
- adjust the Notion router to call the shared helper and translate authorization failures into HTTP responses

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df7329d118832ab5a207b5bc3319c1