### PR TITLE
Add Notion token refresh helpers

### DIFF
--- a/backend/agents/60-tasks/TASK-2025-02-Notion-Refresh.md
+++ b/backend/agents/60-tasks/TASK-2025-02-Notion-Refresh.md
@@ -1,0 +1,17 @@
+---
+id: TASK-2025-02-NOTION-REFRESH
+status: done
+owner: backend
+updated: 2025-02-14
+---
+
+## Request
+- 사용자 피드백: Notion OAuth 연동 후 리프레시 토큰을 이용한 access_token 재발급 로직이 없음.
+
+## Approach
+- 기존 `backend/notions/notion.py` 유틸을 확장해 토큰 만료 판단 및 재발급 헬퍼를 추가한다.
+- 필요 시에만 Notion API `grant_type=refresh_token` 호출하도록 구현한다.
+
+## Result
+- `should_refresh_token`, `refresh_access_token`, `ensure_valid_access_token` 등 유틸을 추가해 토큰 만료시 자동 재발급이 가능하다.
+- 워크스페이스 ID로 자격증명을 조회하는 헬퍼와 토큰 응답 머지 로직을 보강했다.

--- a/backend/notions/__init__.py
+++ b/backend/notions/__init__.py
@@ -6,6 +6,10 @@ from .notion import (
     verify_state,
     exchange_code_for_tokens,
     apply_oauth_tokens,
+    should_refresh_token,
+    get_credential_by_workspace_id,
+    refresh_access_token,
+    ensure_valid_access_token,
 )
 
 __all__ = [
@@ -14,4 +18,8 @@ __all__ = [
     "verify_state",
     "exchange_code_for_tokens",
     "apply_oauth_tokens",
+    "should_refresh_token",
+    "get_credential_by_workspace_id",
+    "refresh_access_token",
+    "ensure_valid_access_token",
 ]


### PR DESCRIPTION
## Summary
- extend the Notion OAuth utility with helpers to detect expirations and refresh access tokens
- expose the new helpers for reuse and record the implementation in the engineering log

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e20701b9d0832aad259bd4260cda5e