### PR TITLE
Remove configurable Chroma persist directory

### DIFF
--- a/backend/agents/40-stories/US-002.3-노션RAG적재.md
+++ b/backend/agents/40-stories/US-002.3-노션RAG적재.md
@@ -11,7 +11,7 @@
 
 ## 2) 선행 조건
 - 환경 변수 `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_EMBEDDING_DEPLOYMENT`가 올바르게 설정돼 있어야 합니다.
-- 선택적으로 `CHROMA_PERSIST_DIRECTORY`로 Chroma 데이터 보존 경로를 지정할 수 있습니다. 미설정 시 기본 경로(`./storage/chroma`)를 사용합니다.
+- Chroma 데이터는 백엔드 컨테이너의 `backend/storage/workspace` 경로에 워크스페이스 단위로 보존됩니다.
 - 노션 워크스페이스와 자격 증명이 이미 연결돼 있어 `/notion/pages/pull`이 페이지 내용을 가져올 수 있어야 합니다.
 
 ---

--- a/backend/rag/chroma.py
+++ b/backend/rag/chroma.py
@@ -12,20 +12,10 @@ from langchain_openai import AzureOpenAIEmbeddings  # Azure OpenAI 임베딩 클
 
 from utils.workspace_storage import (  # 워크스페이스별 스토리지 경로 유틸리티 임포트 주석
     ensure_workspace_storage,
-    slugify_workspace_name,
     workspace_storage_path,
 )
 
 _DEFAULT_STORAGE_ROOT = workspace_storage_path("_").parent  # 기본 RAG 스토리지 루트를 정의하는 주석
-
-
-def _resolve_storage_root(custom_dir: str | None = None) -> Path:  # 저장 디렉터리를 결정하는 헬퍼 함수 정의 주석
-    """워크스페이스별 Chroma 데이터를 보관할 기본 디렉터리를 반환합니다."""  # 함수 목적을 설명하는 주석
-
-    if custom_dir:  # 사용자 지정 경로가 전달되었는지 확인하는 조건 주석
-        return Path(custom_dir).expanduser().resolve()  # 사용자 경로를 절대경로로 변환하여 반환 주석
-
-    return _DEFAULT_STORAGE_ROOT  # 기본 경로의 상위 디렉터리를 반환하는 주석
 
 
 def _load_azure_openai_config() -> dict[str, str]:  # Azure OpenAI 설정을 로드하는 헬퍼 함수 정의 주석
@@ -62,8 +52,8 @@ def _load_azure_openai_config() -> dict[str, str]:  # Azure OpenAI 설정을 로
 class ChromaRAGService:  # Chroma 기반 RAG 서비스를 위한 클래스 정의 주석
     """Chroma 벡터 스토어에 문서를 적재하는 헬퍼입니다."""  # 클래스 역할 설명 주석
 
-    def __init__(self, persist_directory: str | None = None) -> None:  # 초기화 메서드 정의 주석
-        self._storage_root = _resolve_storage_root(persist_directory)  # 기본 스토리지 디렉터리를 Path로 저장하는 주석
+    def __init__(self) -> None:  # 초기화 메서드 정의 주석
+        self._storage_root = _DEFAULT_STORAGE_ROOT  # 기본 스토리지 디렉터리를 Path로 저장하는 주석
         self._storage_root.mkdir(parents=True, exist_ok=True)  # 스토리지 루트 디렉터리를 미리 생성하는 주석
         self._vectorstores: dict[int, Chroma] = {}  # 워크스페이스별 Chroma 인스턴스 캐시 딕셔너리 초기화 주석
 
@@ -71,13 +61,7 @@ class ChromaRAGService:  # Chroma 기반 RAG 서비스를 위한 클래스 정�
         return f"workspace-{workspace_idx}"  # 워크스페이스 식별자를 포함한 컬렉션 이름 반환 주석
 
     def _workspace_directory(self, workspace_name: str) -> Path:  # 워크스페이스 전용 디렉터리를 반환하는 내부 메서드 주석
-        if self._storage_root == _DEFAULT_STORAGE_ROOT:  # 기본 스토리지 루트를 사용하는지 확인하는 주석
-            return ensure_workspace_storage(workspace_name)  # 유틸을 통해 워크스페이스 디렉터리를 생성/반환하는 주석
-
-        slug = slugify_workspace_name(workspace_name)  # 워크스페이스 이름을 슬러그로 변환하는 주석
-        directory = self._storage_root / slug  # 기본 스토리지 경로 아래 슬러그 디렉터리 경로를 구성하는 주석
-        directory.mkdir(parents=True, exist_ok=True)  # 디렉터리가 없으면 생성하는 주석
-        return directory  # 생성된 디렉터리를 반환하는 주석
+        return ensure_workspace_storage(workspace_name)  # 유틸을 통해 워크스페이스 디렉터리를 생성/반환하는 주석
 
     def _create_embeddings(self) -> AzureOpenAIEmbeddings:  # Azure OpenAI 임베딩 인스턴스를 생성하는 내부 메서드 정의 주석
         config = _load_azure_openai_config()  # Azure OpenAI 설정을 로드하는 주석


### PR DESCRIPTION
## Summary
- simplify the Chroma RAG service to always persist data under the default workspace storage path
- update the Notion RAG scenario documentation to describe the fixed storage location instead of the removed environment variable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e38afa9060832aa8be162706e4a364