### PR TITLE
Refactor RAG search to rely solely on LangChain

### DIFF
--- a/backend/docs/rag_search_pipeline.md
+++ b/backend/docs/rag_search_pipeline.md
@@ -1,0 +1,40 @@
+# 워크스페이스 RAG 검색·답변 파이프라인 정리
+
+## 1. 개요
+본 문서는 2025-10-09 이후 개편된 워크스페이스 RAG 검색과 답변 생성 흐름을 설명한다. Cohere 기반 재정렬 단계를 제거하고 LangChain 런너블 체인을 활용해 검색과 답변 생성을 일관된 파이프라인으로 구성했다.
+
+## 2. 검색 전략 구성
+- **SearchStrategy** 열거형은 `vector`, `keyword`, `hybrid` 세 가지 전략을 지원한다.
+- `ChromaRAGService`는 워크스페이스별 벡터 스토어와 BM25 인덱스를 관리한다.
+  - `similarity_search_with_score`: 순수 벡터 검색.
+  - `keyword_search_with_score`: BM25 기반 키워드 검색.
+  - `hybrid_search_with_score`: 가중치(`alpha`)와 RRF 결합(`rrf_k`)을 이용한 하이브리드 검색.
+- LangChain `Document` 객체와 점수 쌍을 반환하도록 정규화하여 이후 단계가 입력 형식에 의존하지 않도록 했다.
+
+## 3. 컨텍스트 구축
+- `_build_context`는 각 문서를 순회하며 `[번호] 제목/URL/본문` 형태의 블록을 만든다.
+- `context_index` 계산을 위해 `chunk_id`, `page_id`, `rag_document_id`를 맵에 기록한다.
+- 컨텍스트가 12,000자 이상이면 문서 수를 줄여 프롬프트 길이를 제한한다.
+
+## 4. LangChain 기반 답변 체인
+- `_ensure_response_chain`은 LangChain `RunnableMap`과 `RunnableLambda`로 질문·컨텍스트를 프롬프트에 주입하는 시퀀스를 구성한다.
+- 프롬프트 → `AzureChatOpenAI` → `StrOutputParser` 순으로 연결된 `RunnableSequence`를 재사용한다.
+- 체인은 `invoke({"question": ..., "context": ...})` 호출만으로 답변을 생성하며, LangChain이 재시도와 스트리밍 옵션을 관리할 수 있다.
+
+## 5. 출처 정리
+- `_build_citations`는 중복 청크를 제거하고 요약 스니펫, 점수, `context_index`를 포함하는 `Citation` 객체 목록을 생성한다.
+- 이 정보는 `SearchResponse` 직렬화 시 그대로 활용되어 UI에서 근거 표기가 가능하다.
+
+## 6. 파라미터 기본값
+- `top_k`는 최소 1, 최대 10으로 제한한다.
+- 하이브리드 검색은 `hybrid_alpha`(0 < α ≤ 1)와 `hybrid_rrf_k`(기본 60)를 사용한다.
+- Cohere Rerank 옵션이 제거되면서 후보 수 산정은 `top_k` 기반으로 간소화되었다.
+
+## 7. 예외 처리
+- 질문이 비어 있으면 `ValueError`로 클라이언트에 400 응답을 보낸다.
+- Azure OpenAI 설정이 누락되면 명시적인 `RuntimeError`를 발생시켜 500 응답으로 매핑한다.
+- LLM 호출 실패 시 경고 로그와 함께 사용자에게 재시도를 안내하는 메시지를 반환한다.
+
+## 8. 후속 작업 아이디어
+- LangChain `Runnable`을 이용해 검색 결과 로그를 비동기 저장하는 후처리 단계를 추가할 수 있다.
+- 사용자 피드백을 반영해 `hybrid_alpha`를 자동 조정하거나, 필요 시 추가적인 재정렬 모델을 도입할 수 있도록 확장성을 확보했다.

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,7 +18,6 @@ dependencies = [
     "langchain-chroma>=0.1.4,<0.2.0",
     "langchain-openai>=0.2.5",
     "rank-bm25>=0.2.2",
-    "cohere>=5.5.7",
     "python-docx>=1.2.0",
     "python-dotenv>=1.1.1",
     "python-multipart>=0.0.20",

--- a/backend/routers/aiagent.py
+++ b/backend/routers/aiagent.py
@@ -53,8 +53,6 @@ async def search_workspace_documents(
             top_k=payload.top_k,
             storage_uri=storage_uri,
             strategy=payload.strategy,
-            rerank_provider=payload.rerank_provider,
-            rerank_top_n=payload.rerank_top_n,
             hybrid_alpha=payload.hybrid_alpha
             if payload.hybrid_alpha is not None
             else 0.6,

--- a/backend/schema/aiagent.py
+++ b/backend/schema/aiagent.py
@@ -21,16 +21,6 @@ class SearchRequest(BaseModel):
         default=SearchStrategy.VECTOR,
         description="검색 전략 (vector | keyword | hybrid)",
     )
-    rerank_provider: str | None = Field(
-        default=None,
-        description="결과 재정렬에 사용할 프로바이더 (예: cohere)",
-    )
-    rerank_top_n: int | None = Field(
-        default=None,
-        ge=1,
-        le=10,
-        description="재정렬 시 고려할 상위 문서 수",
-    )
     hybrid_alpha: float | None = Field(
         default=None,
         ge=0.1,

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -50,7 +50,6 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "chromadb" },
-    { name = "cohere" },
     { name = "cryptography" },
     { name = "fastapi", extra = ["all"] },
     { name = "httpx" },
@@ -73,7 +72,6 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "chromadb", specifier = ">=0.5.6,<0.6.0" },
-    { name = "cohere", specifier = ">=5.5.7" },
     { name = "cryptography", specifier = ">=46.0.1" },
     { name = "fastapi", extras = ["all"], specifier = ">=0.117.1" },
     { name = "httpx", specifier = ">=0.28.1" },
@@ -426,26 +424,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/46/61/de6cd827efad202d7057d93e0fed9294b96952e188f7384832791c7b2254/click-8.3.0.tar.gz", hash = "sha256:e7b8232224eba16f4ebe410c25ced9f7875cb5f3263ffc93cc3e8da705e229c4", size = 276943, upload-time = "2025-09-18T17:32:23.696Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/d3/9dcc0f5797f070ec8edf30fbadfb200e71d9db6b84d211e3b2085a7589a0/click-8.3.0-py3-none-any.whl", hash = "sha256:9b9f285302c6e3064f4330c05f05b81945b2a39544279343e6e7c5f27a9baddc", size = 107295, upload-time = "2025-09-18T17:32:22.42Z" },
-]
-
-[[package]]
-name = "cohere"
-version = "5.18.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "fastavro" },
-    { name = "httpx" },
-    { name = "httpx-sse" },
-    { name = "pydantic" },
-    { name = "pydantic-core" },
-    { name = "requests" },
-    { name = "tokenizers" },
-    { name = "types-requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/f5/4682a965449826044c853c82796805f8d3e9214471e2f120db3063116584/cohere-5.18.0.tar.gz", hash = "sha256:93a7753458a45cd30c796300182d22bb1889eadc510727e1de3d8342cb2bc0bf", size = 164340, upload-time = "2025-09-12T14:17:16.776Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/23/9b/3dc80542e60c711d57777b836a64345dda28f826c14fd64d9123278fcbfe/cohere-5.18.0-py3-none-any.whl", hash = "sha256:885e7be360206418db39425faa60dbcd7f38e39e7f84b824ee68442e6a436e93", size = 295384, upload-time = "2025-09-12T14:17:15.421Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- streamline the workspace RAG search agent to use a reusable LangChain runnable chain and drop Cohere rerank support
- remove rerank-related request fields and dependencies while cleaning up the lockfile
- document the updated retrieval and answer generation pipeline for future development

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68e4bd920d80832a90b270daec2fc6a2