### PR TITLE
Load hybrid RRF parameter from environment

### DIFF
--- a/backend/agents/50-tasks/TASK-013.3-rag-search-hybrid-only.md
+++ b/backend/agents/50-tasks/TASK-013.3-rag-search-hybrid-only.md
@@ -1,0 +1,24 @@
+---
+id: TASK-0013.3
+type: task
+title: 워크스페이스 RAG 검색 하이브리드 전략 고정 및 환경변수화
+status: done
+owner: backend
+updated: 2025-10-10
+---
+
+## 요청 사항
+- `/aiagent/search` API가 항상 하이브리드 검색을 사용하도록 수정합니다.
+- 검색 파라미터 `top_k`, `hybrid_alpha`를 프론트 입력 대신 `.env` 환경 변수(`TOP_K`, `HYBRID_ALPHA`)로 제어합니다.
+- 불필요한 검색 전략 분기와 관련 스키마 필드를 제거합니다.
+- `ChromaRAGService.hybrid_search_with_score`의 후보 계산 구간에 대한 한국어 주석을 추가합니다.
+
+## 진행 기록
+- 2025-10-10: 요구사항 파악 및 관련 코드 베이스 분석.
+- 2025-10-10: `/aiagent/search` 요청 스키마와 라우터에서 전략·파라미터 입력을 제거하고 에이전트가 환경 변수 기반 하이브리드 검색만 수행하도록 정리.
+- 2025-10-10: `ChromaRAGService.hybrid_search_with_score`에 주석을 추가하고 불필요한 검색 헬퍼를 제거하여 내부에서 직접 벡터·BM25 검색을 조합하도록 수정.
+
+## 결과
+- 백엔드가 `.env`의 `TOP_K`, `HYBRID_ALPHA` 값으로만 검색 파라미터를 제어하며, API는 질문 문자열만 받는다.
+- 하이브리드 검색 경로 외 코드가 정리되어 유지보수 범위가 축소되고, 후보 계산 로직에는 한국어 주석이 추가되었다.
+

--- a/backend/routers/aiagent.py
+++ b/backend/routers/aiagent.py
@@ -50,12 +50,7 @@ async def search_workspace_documents(
             workspace_idx=context.workspace.idx,
             workspace_name=context.workspace.name,
             query=payload.query,
-            top_k=payload.top_k,
             storage_uri=storage_uri,
-            strategy=payload.strategy,
-            hybrid_alpha=payload.hybrid_alpha
-            if payload.hybrid_alpha is not None
-            else 0.6,
         )
     except ValueError as exc:
         raise HTTPException(

--- a/backend/schema/aiagent.py
+++ b/backend/schema/aiagent.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import asdict
 from typing import Annotated, List
 
-from pydantic import BaseModel, Field, StringConstraints
+from pydantic import BaseModel, StringConstraints
 
-from ai_module.rag_search import Citation, SearchResult, SearchStrategy
+from ai_module.rag_search import Citation, SearchResult
 
 QueryStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, max_length=2000)]
 
@@ -16,17 +16,6 @@ class SearchRequest(BaseModel):
     """워크스페이스 문서 검색 요청 페이로드."""
 
     query: QueryStr
-    top_k: int = Field(default=4, ge=1, le=16, description="반환할 최대 문서 수")
-    strategy: SearchStrategy = Field(
-        default=SearchStrategy.VECTOR,
-        description="검색 전략 (vector | keyword | hybrid)",
-    )
-    hybrid_alpha: float | None = Field(
-        default=None,
-        ge=0.1,
-        le=1.0,
-        description="하이브리드 검색 시 벡터 가중치 (0.1~1.0)",
-    )
 
 
 class SearchCitation(BaseModel):


### PR DESCRIPTION
## Summary
- add a helper to read HYBRID_RRF_K from the environment with validation
- update the workspace RAG search agent to default hybrid_rrf_k from the new loader while preserving manual overrides

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4cf201d50832ab895f373b7de605f