### PR TITLE
Download Google Drive files as workspace PDFs for RAG

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -26,4 +26,5 @@ dependencies = [
     "uvicorn>=0.36.0",
     "google-auth-oauthlib>=1.2.3",
     "google-api-python-client>=2.187.0",
+    "pypdf>=4.3.1",
 ]


### PR DESCRIPTION
## Summary
- download convertible Google Drive files as PDFs into each workspace storage folder and extract text for RAG ingestion with detailed logging
- update the Google Drive pull endpoint to direct downloads into the workspace PDF directory and expose stored PDF paths in the response metadata
- add the pypdf dependency required for PDF parsing

## Testing
- uv run python -m compileall backend/google_drive

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69145d623d18832a832ca88ba094bd7f)