### PR TITLE
Implement Google Drive incremental sync via Changes API

### DIFF
--- a/backend/agents/50-tasks/TASK-022.5-google-drive-changes-sync.md
+++ b/backend/agents/50-tasks/TASK-022.5-google-drive-changes-sync.md
@@ -1,0 +1,23 @@
+---
+id: TASK-0022.5
+type: task
+title: Google Drive Changes API 증분 동기화 구현
+status: done
+owner: backend
+updated: 2025-10-31
+---
+
+## 요청 사항
+- Google Drive Changes API를 사용해 워크스페이스 루트 폴더 이하의 파일 추가/수정/이동/삭제를 증분 동기화한다.
+- 파일 콘텐츠 변경 여부를 md5Checksum(바이너리)와 version/modifiedTime(Google Docs 계열) 기준으로 판단한다.
+- “오래전에 만든 문서를 오늘 업로드한 경우”도 누락되지 않도록 인덱싱한다.
+- RAG 인덱스와 메타데이터를 정확히 갱신하고, 초기 상태에서는 전체 부트스트랩을 수행한다.
+
+## 진행 기록
+- 2025-10-31: Google Drive Changes API 클라이언트(`change_stream.py`)를 추가하고, 루트 트리 필터링 및 폴더 조상 탐색 로직을 구현했다.
+- 2025-10-31: 증분 상태/파일 스냅샷 테이블과 SQLAlchemy 모델을 추가하여 md5Checksum·version 기반 변경 감지를 저장하도록 했다.
+- 2025-10-31: `/google-drive/files/pull` 라우터를 증분 흐름으로 재구성하고, 삭제/이동 감지 시 RAG 문서를 제거하도록 확장했다.
+
+## 결과
+- Changes API 기반으로 Google Drive 워크스페이스 파일 증분 동기화가 가능하며, 신규 업로드/이동/삭제에 대응해 RAG 인덱스가 최신 상태로 유지된다.
+- 파일 스냅샷 메타데이터를 활용해 불필요한 재처리를 줄이고, 제거된 문서는 벡터 스토어에서 자동 삭제된다.

--- a/backend/google_drive/change_stream.py
+++ b/backend/google_drive/change_stream.py
@@ -1,0 +1,347 @@
+"""Google Drive Changes API 통합 로직."""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+import httpx
+
+from .files import (
+    CONVERTIBLE_MIME_TYPES,
+    FILES_ENDPOINT,
+    GoogleDriveAPIError,
+)
+
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+CHANGES_ENDPOINT = "https://www.googleapis.com/drive/v3/changes"
+START_PAGE_TOKEN_ENDPOINT = f"{CHANGES_ENDPOINT}/startPageToken"
+
+_CHANGE_FIELDS = (
+    "nextPageToken,newStartPageToken,"
+    "changes(fileId,removed,changeType,time,file("
+    "id,name,mimeType,modifiedTime,md5Checksum,version,parents,"
+    "webViewLink,trashed,capabilities/canDownload)))"
+)
+
+_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+
+
+@dataclass(slots=True)
+class ChangeBatch:
+    """Changes API 호출 결과를 구조화한 데이터 컨테이너."""
+
+    to_index: List[Dict[str, Any]]
+    to_remove: List[str]
+    skipped: List[Dict[str, str]]
+    new_start_page_token: str
+
+
+async def get_start_page_token(access_token: str) -> str:
+    """Google Drive Changes API용 startPageToken을 조회한다."""
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    params = {"supportsAllDrives": "false"}
+
+    async with httpx.AsyncClient(timeout=30) as client:
+        response = await client.get(
+            START_PAGE_TOKEN_ENDPOINT, headers=headers, params=params
+        )
+
+    if response.status_code != 200:
+        raise GoogleDriveAPIError(response.text)
+
+    payload = response.json()
+    token = payload.get("startPageToken")
+    if not token:
+        raise GoogleDriveAPIError("startPageToken을 가져오지 못했습니다.")
+    return str(token)
+
+
+async def list_workspace_files(
+    access_token: str,
+    *,
+    root_id: str,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, str]]]:
+    """워크스페이스 루트 이하의 변환 가능한 파일 목록을 반환한다."""
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+    params = {
+        "pageSize": 200,
+        "fields": (
+            "nextPageToken, files(id, name, mimeType, modifiedTime, md5Checksum,"
+            " version, webViewLink, parents, capabilities/canDownload)"
+        ),
+        "supportsAllDrives": "false",
+        "includeItemsFromAllDrives": "false",
+        "orderBy": "modifiedTime desc",
+        "q": None,
+    }
+
+    convertible: List[Dict[str, Any]] = []
+    skipped: List[Dict[str, str]] = []
+    queue: deque[str] = deque([root_id])
+    visited: set[str] = set()
+
+    async with httpx.AsyncClient(timeout=60) as client:
+        while queue:
+            folder_id = queue.popleft()
+            if folder_id in visited:
+                continue
+            visited.add(folder_id)
+
+            folder_query = _build_folder_query(folder_id)
+            params["q"] = folder_query
+
+            page_token: Optional[str] = None
+            while True:
+                if page_token:
+                    params["pageToken"] = page_token
+                else:
+                    params.pop("pageToken", None)
+
+                response = await client.get(
+                    FILES_ENDPOINT, headers=headers, params=params
+                )
+                if response.status_code != 200:
+                    raise GoogleDriveAPIError(response.text)
+
+                payload = response.json()
+                files = payload.get("files", [])
+                for file in files:
+                    mime_type = file.get("mimeType") or ""
+                    file_id = file.get("id") or ""
+                    if mime_type == _FOLDER_MIME_TYPE:
+                        if file_id:
+                            queue.append(file_id)
+                        continue
+
+                    if mime_type not in CONVERTIBLE_MIME_TYPES:
+                        skipped.append(
+                            {
+                                "file_id": file_id,
+                                "name": file.get("name") or "",
+                                "mime_type": mime_type,
+                                "reason": "지원하지 않는 형식입니다.",
+                            }
+                        )
+                        continue
+
+                    convertible.append(file)
+
+                page_token = payload.get("nextPageToken")
+                if not page_token:
+                    break
+
+    logger.info(
+        "Google Drive 루트(%s) 이하에서 %d개의 변환 대상 파일을 찾았습니다.",
+        root_id,
+        len(convertible),
+    )
+    return convertible, skipped
+
+
+async def collect_workspace_changes(
+    access_token: str,
+    *,
+    page_token: str,
+    root_id: str,
+) -> ChangeBatch:
+    """Changes API를 통해 증분 변경을 수집한다."""
+
+    headers = {"Authorization": f"Bearer {access_token}"}
+
+    to_index: Dict[str, Dict[str, Any]] = {}
+    to_remove: set[str] = set()
+    skipped: Dict[str, Dict[str, str]] = {}
+    new_start_page_token = page_token
+
+    parents_cache: Dict[str, bool] = {}
+
+    async with httpx.AsyncClient(timeout=60) as client:
+        next_token: Optional[str] = page_token
+        while next_token:
+            params = {
+                "pageToken": next_token,
+                "pageSize": 200,
+                "fields": _CHANGE_FIELDS,
+                "includeItemsFromAllDrives": "false",
+                "supportsAllDrives": "false",
+                "restrictToMyDrive": "true",
+            }
+
+            response = await client.get(CHANGES_ENDPOINT, headers=headers, params=params)
+            if response.status_code != 200:
+                raise GoogleDriveAPIError(response.text)
+
+            payload = response.json()
+            new_start_page_token = payload.get("newStartPageToken") or new_start_page_token
+
+            for change in payload.get("changes", []):
+                change_type = change.get("changeType")
+                if change_type and change_type != "file":
+                    continue
+
+                file_id = change.get("fileId") or ""
+                if not file_id:
+                    continue
+
+                if change.get("removed"):
+                    _mark_removed(file_id, to_index, to_remove, skipped)
+                    continue
+
+                file = change.get("file") or {}
+                if file.get("trashed"):
+                    _mark_removed(file_id, to_index, to_remove, skipped)
+                    continue
+
+                mime_type = file.get("mimeType") or ""
+                if mime_type == _FOLDER_MIME_TYPE:
+                    continue
+
+                if mime_type not in CONVERTIBLE_MIME_TYPES:
+                    skipped[file_id] = {
+                        "file_id": file_id,
+                        "name": file.get("name") or "",
+                        "mime_type": mime_type,
+                        "reason": "지원하지 않는 형식입니다.",
+                    }
+                    to_index.pop(file_id, None)
+                    to_remove.discard(file_id)
+                    continue
+
+                capabilities = file.get("capabilities") or {}
+                if not capabilities.get("canDownload", True):
+                    skipped[file_id] = {
+                        "file_id": file_id,
+                        "name": file.get("name") or "",
+                        "mime_type": mime_type,
+                        "reason": "다운로드 권한이 없습니다.",
+                    }
+                    to_index.pop(file_id, None)
+                    to_remove.discard(file_id)
+                    continue
+
+                parents: Iterable[str] = file.get("parents") or []
+                if parents and await _is_within_workspace(
+                    client, headers, parents, root_id, parents_cache
+                ):
+                    to_remove.discard(file_id)
+                    skipped.pop(file_id, None)
+                    to_index[file_id] = file
+                else:
+                    _mark_removed(file_id, to_index, to_remove, skipped)
+
+            next_token = payload.get("nextPageToken")
+
+    return ChangeBatch(
+        to_index=list(to_index.values()),
+        to_remove=list(to_remove),
+        skipped=list(skipped.values()),
+        new_start_page_token=new_start_page_token,
+    )
+
+
+def _mark_removed(
+    file_id: str,
+    to_index: Dict[str, Dict[str, Any]],
+    to_remove: set[str],
+    skipped: Dict[str, Dict[str, str]],
+) -> None:
+    """변경된 파일을 제거 대상으로 표시한다."""
+
+    if not file_id:
+        return
+    to_index.pop(file_id, None)
+    skipped.pop(file_id, None)
+    to_remove.add(file_id)
+
+
+def _build_folder_query(folder_id: str) -> str:
+    """폴더 내 모든 하위 항목을 검색하기 위한 쿼리를 생성한다."""
+
+    convertible_query = " or ".join(
+        f"mimeType = '{mime}'" for mime in sorted(CONVERTIBLE_MIME_TYPES)
+    )
+    return " and ".join(
+        filter(
+            None,
+            [
+                "trashed=false",
+                "'me' in owners",
+                f"(({convertible_query}) or mimeType = '{_FOLDER_MIME_TYPE}')",
+                f"'{folder_id}' in parents",
+            ],
+        )
+    )
+
+
+async def _is_within_workspace(
+    client: httpx.AsyncClient,
+    headers: Dict[str, str],
+    parents: Iterable[str],
+    root_id: str,
+    cache: Dict[str, bool],
+) -> bool:
+    """파일이 워크스페이스 루트 하위에 존재하는지 확인한다."""
+
+    for parent_id in parents:
+        if parent_id == root_id:
+            return True
+        if await _has_root_ancestor(client, headers, parent_id, root_id, cache, set()):
+            return True
+    return False
+
+
+async def _has_root_ancestor(
+    client: httpx.AsyncClient,
+    headers: Dict[str, str],
+    folder_id: str,
+    root_id: str,
+    cache: Dict[str, bool],
+    visiting: set[str],
+) -> bool:
+    if folder_id == root_id:
+        return True
+    if folder_id in visiting:
+        return False
+
+    cached = cache.get(folder_id)
+    if cached is not None:
+        return cached
+
+    visiting.add(folder_id)
+    metadata = await _fetch_folder_metadata(client, headers, folder_id)
+    parents = metadata.get("parents") or []
+    for parent in parents:
+        if parent == root_id or await _has_root_ancestor(
+            client, headers, parent, root_id, cache, visiting
+        ):
+            cache[folder_id] = True
+            visiting.discard(folder_id)
+            return True
+
+    visiting.discard(folder_id)
+    cache[folder_id] = False
+    return False
+
+
+async def _fetch_folder_metadata(
+    client: httpx.AsyncClient,
+    headers: Dict[str, str],
+    folder_id: str,
+) -> Dict[str, Any]:
+    response = await client.get(
+        f"{FILES_ENDPOINT}/{folder_id}",
+        headers=headers,
+        params={"fields": "id, parents"},
+    )
+    if response.status_code != 200:
+        raise GoogleDriveAPIError(response.text)
+    return response.json()
+

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -9,6 +9,8 @@ from .entities import (
     User,
     NotionOauthCredentials,
     GoogleDriveOauthCredentials,
+    GoogleDriveFileSnapshot,
+    GoogleDriveSyncState,
     DataSource,
 )
 
@@ -26,6 +28,8 @@ __all__ = [
     "User",
     "NotionOauthCredentials",
     "GoogleDriveOauthCredentials",
+    "GoogleDriveFileSnapshot",
+    "GoogleDriveSyncState",
     "DataSource",
     "DEFAULT_RAG_INDEX_NAME",
 ]

--- a/backend/models/entities.py
+++ b/backend/models/entities.py
@@ -5,7 +5,18 @@ from __future__ import annotations
 from datetime import datetime
 from enum import Enum
 
-from sqlalchemy import BigInteger, Column, DateTime, String, Boolean, Text, JSON, Integer, text
+from sqlalchemy import (
+    BigInteger,
+    Column,
+    DateTime,
+    String,
+    Boolean,
+    Text,
+    JSON,
+    Integer,
+    UniqueConstraint,
+    text,
+)
 
 from utils.db import Base
 
@@ -131,3 +142,41 @@ class GoogleDriveOauthCredentials(Base):
     created = Column(DateTime, nullable=False, default=lambda: datetime.utcnow())
     updated = Column(DateTime, nullable=False, default=lambda: datetime.utcnow())
     provider_payload = Column(JSON, nullable=True)
+
+
+class GoogleDriveSyncState(Base):
+    """Google Drive Changes API 증분 동기화 상태."""
+
+    __tablename__ = "google_drive_sync_state"
+
+    idx = Column(BigInteger, primary_key=True, autoincrement=True)
+    data_source_idx = Column(BigInteger, nullable=False, unique=True)
+    start_page_token = Column(String(255), nullable=True)
+    latest_history_id = Column(String(255), nullable=True)
+    bootstrapped_at = Column(DateTime, nullable=True)
+    last_synced = Column(DateTime, nullable=True)
+    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+
+class GoogleDriveFileSnapshot(Base):
+    """Google Drive에서 인덱싱한 파일 스냅샷."""
+
+    __tablename__ = "google_drive_file_snapshots"
+
+    idx = Column(BigInteger, primary_key=True, autoincrement=True)
+    data_source_idx = Column(BigInteger, nullable=False)
+    file_id = Column(String(128), nullable=False)
+    name = Column(String(1024), nullable=True)
+    mime_type = Column(String(255), nullable=False)
+    md5_checksum = Column(String(128), nullable=True)
+    version = Column(BigInteger, nullable=True)
+    modified_time = Column(DateTime, nullable=True)
+    web_view_link = Column(String(1024), nullable=True)
+    last_synced = Column(DateTime, nullable=False, default=datetime.utcnow)
+    created = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    __table_args__ = (
+        UniqueConstraint("data_source_idx", "file_id", name="uk_google_drive_file"),
+    )

--- a/backend/rag/chroma.py
+++ b/backend/rag/chroma.py
@@ -240,6 +240,36 @@ class ChromaRAGService:
         self._invalidate_keyword_index(key)
         return len(docs)
 
+    def delete_documents(
+        self,
+        workspace_idx: int,
+        workspace_name: str,
+        page_ids: Sequence[str],
+        *,
+        storage_uri: Optional[str] = None,
+    ) -> int:
+        """특정 page_id에 해당하는 문서를 제거한다."""
+
+        if not page_ids:
+            return 0
+
+        store = self._get_vectorstore(
+            workspace_idx, workspace_name, storage_uri=storage_uri
+        )
+        removed = 0
+        for page_id in page_ids:
+            try:
+                store.delete(where={"page_id": page_id})
+                removed += 1
+            except Exception:  # pragma: no cover - 삭제 오류는 무시
+                continue
+
+        key = self._cache_key(
+            workspace_idx, workspace_name, storage_uri=storage_uri
+        )
+        self._invalidate_keyword_index(key)
+        return removed
+
     def collection_stats(
         self,
         workspace_idx: int,

--- a/backend/routers/google_drive.py
+++ b/backend/routers/google_drive.py
@@ -11,7 +11,9 @@ from dependencies import get_current_user
 from models import (
     DEFAULT_RAG_INDEX_NAME,
     DataSource,
+    GoogleDriveFileSnapshot,
     GoogleDriveOauthCredentials,
+    GoogleDriveSyncState,
     RagIndex,
     User,
     Workspace,
@@ -30,9 +32,15 @@ from google_drive import (
     make_state,
     verify_state,
 )
-
+from google_drive.change_stream import (
+    ChangeBatch,
+    collect_workspace_changes,
+    get_start_page_token,
+    list_workspace_files,
+)
 from google_drive.files import (
     GoogleDriveAPIError,
+    GoogleDriveFile,
     build_documents_from_records,
     build_records_from_files,
     fetch_authorized_text_files,
@@ -42,13 +50,133 @@ from rag.chroma import ChromaRAGService
 
 import json
 from datetime import datetime, timezone
-
+from typing import Any, Dict, Iterable, List, Optional
 
 import os
 FRONT_MAIN_REDIRECT_URL=os.getenv("FRONT_MAIN_REDIRECT_URL")
 
 router = APIRouter(prefix="/google-drive", tags=["google-drive"])
 rag_service = ChromaRAGService()
+
+
+def _resolve_root_folder_id(credential: GoogleDriveOauthCredentials) -> str:
+    """워크스페이스로 지정된 Google Drive 루트 폴더 ID를 반환한다."""
+
+    payload: Any = credential.provider_payload or {}
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError:
+            payload = {}
+
+    if isinstance(payload, dict):
+        root_id = (
+            payload.get("workspace_root_id")
+            or payload.get("root_folder_id")
+            or payload.get("selected_folder_id")
+        )
+    else:
+        root_id = None
+
+    return str(root_id) if root_id else "root"
+
+
+def _parse_google_datetime(value: Optional[str]) -> Optional[datetime]:
+    """Google ISO8601 문자열을 UTC datetime으로 변환한다."""
+
+    if not value:
+        return None
+
+    try:
+        normalized = value.replace("Z", "+00:00")
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    """정수 변환 실패 시 None을 반환한다."""
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _should_reindex(
+    metadata: Dict[str, Any], snapshot: Optional[GoogleDriveFileSnapshot]
+) -> bool:
+    """파일 메타데이터 변화로 재색인 필요 여부를 판단한다."""
+
+    if snapshot is None:
+        return True
+
+    checksum = metadata.get("md5Checksum") or None
+    version = _safe_int(metadata.get("version"))
+    modified_time = _parse_google_datetime(metadata.get("modifiedTime"))
+
+    if checksum:
+        return snapshot.md5_checksum != checksum
+
+    if version is not None:
+        if snapshot.version is None:
+            return True
+        return snapshot.version != version
+
+    if snapshot.version is not None:
+        return True
+
+    if not modified_time:
+        return False
+
+    if snapshot.modified_time is None:
+        return True
+
+    return snapshot.modified_time != modified_time
+
+
+def _apply_snapshot_metadata(
+    snapshot: GoogleDriveFileSnapshot,
+    metadata: Dict[str, Any],
+    *,
+    synced_at: datetime,
+    update_synced: bool,
+) -> None:
+    """스냅샷 레코드에 최신 메타데이터를 반영한다."""
+
+    snapshot.name = metadata.get("name") or snapshot.name
+    mime_type = metadata.get("mimeType") or snapshot.mime_type
+    snapshot.mime_type = mime_type
+    snapshot.md5_checksum = metadata.get("md5Checksum") or None
+    snapshot.version = _safe_int(metadata.get("version"))
+    snapshot.modified_time = _parse_google_datetime(metadata.get("modifiedTime"))
+    snapshot.web_view_link = metadata.get("webViewLink") or snapshot.web_view_link
+    if update_synced:
+        snapshot.last_synced = synced_at
+    snapshot.updated = synced_at
+
+
+def _ensure_sync_state(db: Session, data_source: DataSource) -> GoogleDriveSyncState:
+    """Google Drive 동기화 상태 레코드를 조회하거나 생성한다."""
+
+    sync_state = db.scalar(
+        select(GoogleDriveSyncState).where(
+            GoogleDriveSyncState.data_source_idx == data_source.idx
+        )
+    )
+
+    if sync_state:
+        return sync_state
+
+    sync_state = GoogleDriveSyncState(data_source_idx=data_source.idx)
+    db.add(sync_state)
+    db.commit()
+    db.refresh(sync_state)
+    return sync_state
 
 
 def _resolve_workspace(db: Session, user: User) -> Workspace:
@@ -195,22 +323,127 @@ async def pull_google_drive_files(
             DataSource.type == "googledrive",
         )
     )
-    last_synced_at = data_source.synced if data_source else None
+    if not data_source:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Google Drive 데이터 소스를 찾을 수 없습니다.",
+        )
+
+    sync_state = _ensure_sync_state(db, data_source)
+    last_synced_at = data_source.synced
 
     storage_path = ensure_workspace_storage(workspace.name)
     pdf_download_dir = storage_path / "googledrive" / "pdf"
+    root_folder_id = _resolve_root_folder_id(credential)
 
-    try:
-        files, skipped = await fetch_authorized_text_files(
-            credential.access_token,
-            modified_after=last_synced_at,
-            download_dir=pdf_download_dir,
-        )
-    except GoogleDriveAPIError as exc:
-        raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail=f"Google Drive API 오류: {exc}",
-        ) from exc
+    now = datetime.now(timezone.utc)
+    bootstrapped = False
+    skipped_files: List[Dict[str, str]] = []
+    removed_file_ids: List[str] = []
+    index_candidates: List[Dict[str, Any]] = []
+
+    if not sync_state.start_page_token:
+        try:
+            start_token = await get_start_page_token(credential.access_token)
+            raw_files, bootstrap_skipped = await list_workspace_files(
+                credential.access_token,
+                root_id=root_folder_id,
+            )
+        except GoogleDriveAPIError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Google Drive API 오류: {exc}",
+            ) from exc
+
+        skipped_files.extend(bootstrap_skipped)
+        index_candidates = raw_files
+        new_start_token = start_token
+        bootstrapped = True
+    else:
+        try:
+            change_batch: ChangeBatch = await collect_workspace_changes(
+                credential.access_token,
+                page_token=sync_state.start_page_token,
+                root_id=root_folder_id,
+            )
+        except GoogleDriveAPIError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Google Drive Changes API 오류: {exc}",
+            ) from exc
+
+        index_candidates = change_batch.to_index
+        removed_file_ids = list(dict.fromkeys(change_batch.to_remove))
+        skipped_files.extend(change_batch.skipped)
+        new_start_token = change_batch.new_start_page_token or sync_state.start_page_token
+
+    candidate_ids = {meta.get("id") for meta in index_candidates if meta.get("id")}
+    candidate_ids.update(removed_file_ids)
+    candidate_ids.discard(None)
+
+    snapshots: Dict[str, GoogleDriveFileSnapshot] = {}
+    if candidate_ids:
+        snapshot_rows = db.scalars(
+            select(GoogleDriveFileSnapshot).where(
+                GoogleDriveFileSnapshot.data_source_idx == data_source.idx,
+                GoogleDriveFileSnapshot.file_id.in_(candidate_ids),
+            )
+        ).all()
+        snapshots = {row.file_id: row for row in snapshot_rows}
+
+    files_to_convert: List[Dict[str, Any]] = []
+    for metadata in index_candidates:
+        file_id = metadata.get("id")
+        if not file_id:
+            continue
+        snapshot = snapshots.get(file_id)
+        if _should_reindex(metadata, snapshot):
+            files_to_convert.append(metadata)
+        elif snapshot:
+            _apply_snapshot_metadata(snapshot, metadata, synced_at=now, update_synced=False)
+
+    converted_files: List[GoogleDriveFile] = []
+    conversion_skipped: List[Dict[str, str]] = []
+    if files_to_convert:
+        try:
+            converted_files, conversion_skipped = await fetch_authorized_text_files(
+                credential.access_token,
+                download_dir=pdf_download_dir,
+                files_override=files_to_convert,
+            )
+        except GoogleDriveAPIError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail=f"Google Drive 파일 변환 오류: {exc}",
+            ) from exc
+
+    skipped_files.extend(conversion_skipped)
+
+    meta_by_id = {metadata.get("id"): metadata for metadata in index_candidates if metadata.get("id")}
+
+    for file in converted_files:
+        file_meta = meta_by_id.get(file.file_id)
+        if not file_meta:
+            continue
+        snapshot = snapshots.get(file.file_id)
+        if not snapshot:
+            snapshot = GoogleDriveFileSnapshot(
+                data_source_idx=data_source.idx,
+                file_id=file.file_id,
+                mime_type=file.mime_type,
+            )
+            db.add(snapshot)
+            snapshots[file.file_id] = snapshot
+        _apply_snapshot_metadata(snapshot, file_meta, synced_at=now, update_synced=True)
+
+    removed_ids_clean: List[str] = []
+    for file_id in removed_file_ids:
+        if not file_id:
+            continue
+        removed_ids_clean.append(file_id)
+        snapshot = snapshots.pop(file_id, None)
+        if snapshot:
+            db.delete(snapshot)
 
     workspace_metadata = {
         "workspace_idx": workspace.idx,
@@ -219,7 +452,7 @@ async def pull_google_drive_files(
         "provider": "googledrive",
     }
 
-    records = build_records_from_files(files)
+    records = build_records_from_files(converted_files)
     documents = build_documents_from_records(records, workspace_metadata)
 
     jsonl_lines = [json.dumps(record, ensure_ascii=False) for record in records]
@@ -233,6 +466,15 @@ async def pull_google_drive_files(
     )
 
     storage_uri = rag_index.storage_uri if rag_index and rag_index.storage_uri else str(storage_path)
+
+    removed_pages = 0
+    if removed_ids_clean:
+        removed_pages = rag_service.delete_documents(
+            workspace.idx,
+            workspace.name,
+            removed_ids_clean,
+            storage_uri=storage_uri,
+        )
 
     try:
         if documents:
@@ -268,15 +510,19 @@ async def pull_google_drive_files(
         workspace.name,
         storage_uri=rag_index.storage_uri,
     )
-    now = datetime.now(timezone.utc)
     rag_index.object_count = stats.page_count
     rag_index.vector_count = stats.vector_count
     rag_index.status = "ready"
     rag_index.updated = now
 
-    if data_source:
-        data_source.synced = now
-        db.add(data_source)
+    data_source.synced = now
+    db.add(data_source)
+
+    sync_state.start_page_token = new_start_token
+    sync_state.last_synced = now
+    if bootstrapped:
+        sync_state.bootstrapped_at = now
+    db.add(sync_state)
 
     try:
         db.commit()
@@ -298,12 +544,16 @@ async def pull_google_drive_files(
                 "pdf_path": str(file.pdf_path),
                 "text_length": len(file.text),
             }
-            for file in files
+            for file in converted_files
         ],
         "jsonl_records": records,
         "jsonl_text": jsonl_text,
-        "skipped_files": skipped,
+        "skipped_files": skipped_files,
+        "removed_files": removed_ids_clean,
         "ingested_chunks": ingested_count,
+        "removed_pages": removed_pages,
         "last_synced_at": last_synced_at.isoformat() if last_synced_at else None,
         "synced_at": now.isoformat(),
+        "start_page_token": new_start_token,
+        "bootstrapped": bootstrapped,
     }

--- a/init/init.sql
+++ b/init/init.sql
@@ -130,7 +130,39 @@ CREATE TABLE google_drive_oauth_credentials (
   CONSTRAINT fk_google_cred_ds   FOREIGN KEY (data_source_idx) REFERENCES data_sources(idx)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='구글 드라이브 OAuth 토큰/메타(비밀 값)';
 
--- 8) 노션 동기화 상태(증분/커서만 저장; 컨텐츠는 저장 안 함)
+-- 8) 구글 드라이브 Changes API 동기화 상태
+CREATE TABLE google_drive_sync_state (
+  idx               BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '동기화 상태 PK',
+  data_source_idx   BIGINT NOT NULL UNIQUE            COMMENT 'Google Drive 데이터 소스 FK',
+  start_page_token  VARCHAR(255) NULL                 COMMENT 'Changes API startPageToken',
+  latest_history_id VARCHAR(255) NULL                 COMMENT '마지막 historyId(미사용 가능)',
+  bootstrapped_at   DATETIME NULL                     COMMENT '최초 전체 스캔 완료 시각',
+  last_synced       DATETIME NULL                     COMMENT '마지막 증분 동기화 시각',
+  created           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '레코드 생성 시각',
+  updated           DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '레코드 갱신 시각',
+  CONSTRAINT fk_google_sync_ds FOREIGN KEY (data_source_idx) REFERENCES data_sources(idx)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='구글 드라이브 증분 동기화 상태 저장';
+
+-- 9) 구글 드라이브 파일 스냅샷(변환 기준)
+CREATE TABLE google_drive_file_snapshots (
+  idx            BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '파일 스냅샷 PK',
+  data_source_idx BIGINT NOT NULL                 COMMENT 'Google Drive 데이터 소스 FK',
+  file_id        VARCHAR(128) NOT NULL            COMMENT 'Google Drive 파일 ID',
+  name           VARCHAR(1024) NULL               COMMENT '파일 이름',
+  mime_type      VARCHAR(255) NOT NULL            COMMENT 'MIME 타입',
+  md5_checksum   VARCHAR(128) NULL                COMMENT '바이너리 체크섬',
+  version        BIGINT NULL                      COMMENT 'Google Workspace 파일 버전',
+  modified_time  DATETIME NULL                    COMMENT '마지막 수정 시각',
+  web_view_link  VARCHAR(1024) NULL               COMMENT '웹 링크',
+  last_synced    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '마지막 인덱싱 시각',
+  created        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT '레코드 생성 시각',
+  updated        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP COMMENT '레코드 갱신 시각',
+  UNIQUE KEY uk_google_drive_file (data_source_idx, file_id),
+  KEY idx_google_drive_file_ds (data_source_idx),
+  CONSTRAINT fk_google_drive_file_ds FOREIGN KEY (data_source_idx) REFERENCES data_sources(idx)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='구글 드라이브 파일 콘텐츠 스냅샷';
+
+-- 10) 노션 동기화 상태(증분/커서만 저장; 컨텐츠는 저장 안 함)
 CREATE TABLE notion_data_source_sync_state (
   idx                 BIGINT PRIMARY KEY AUTO_INCREMENT COMMENT '동기화 상태 PK',
   data_source_idx     BIGINT NOT NULL UNIQUE            COMMENT '대상 데이터 소스 FK(1:1)',


### PR DESCRIPTION
## Summary
- add a Google Drive change stream client that filters account changes to the workspace root hierarchy
- persist incremental sync state and per-file snapshots so md5/version deltas trigger re-indexing when appropriate
- rework the Google Drive pull endpoint to consume the change feed, update the RAG index (including deletions), and document the new workflow

## Testing
- uv run pytest *(fails: sympy wheel download blocked by network tunnel)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691571d1eb1c832a83b24a498cfa4400)