### PR TITLE
Add DOCX XML extraction for Google Drive RAG ingestion

### DIFF
--- a/backend/agents/40-stories/US-003.5-구글드라이브PDF다운로드.md
+++ b/backend/agents/40-stories/US-003.5-구글드라이브PDF다운로드.md
@@ -1,7 +1,7 @@
-# Google Drive 파일 PDF 변환 및 워크스페이스 저장 시나리오
+# Google Drive 파일 포맷 변환 및 워크스페이스 저장 시나리오
 
 ## 1) 개요
-Google Drive 데이터 소스가 연결된 사용자가 `/google-drive/files/pull` 엔드포인트를 호출하면, 다운로드/내보내기가 가능한 문서형 파일을 워크스페이스 스토리지에 PDF로 저장하고 RAG 인덱스에 적재한다. 모든 처리 단계는 로거를 통해 기록되며, PDF에서 추출한 텍스트를 기반으로 LangChain 문서를 생성한다.
+Google Drive 데이터 소스가 연결된 사용자가 `/google-drive/files/pull` 엔드포인트를 호출하면, 다운로드/내보내기가 가능한 문서형 파일을 워크스페이스 스토리지에 변환된 포맷(PDF 또는 OpenXML DOCX)으로 저장하고 RAG 인덱스에 적재한다. 모든 처리 단계는 로거를 통해 기록되며, 변환된 파일에서 추출한 텍스트를 기반으로 LangChain 문서를 생성한다. OpenXML로 변환된 경우에는 문서 XML을 메타데이터에 함께 저장한다.
 
 ---
 
@@ -15,7 +15,7 @@ Google Drive 데이터 소스가 연결된 사용자가 `/google-drive/files/pul
 
 ## 3) 엔드포인트 요약
 ### 3.1 `POST /google-drive/files/pull`
-- **목적**: Google Drive 파일을 PDF로 변환 후 워크스페이스 `googledrive/pdf` 디렉터리에 저장하고, 추출 텍스트를 RAG 인덱스에 적재한다.
+- **목적**: Google Drive 파일을 PDF 또는 OpenXML DOCX로 변환 후 워크스페이스 `googledrive/pdf` 디렉터리에 저장하고, 추출 텍스트를 RAG 인덱스에 적재한다. DOCX(OpenXML)로 저장된 경우 `word/document.xml` 내용도 함께 JSONL/메타데이터에 포함한다.
 - **요청 헤더**: `Authorization: Bearer <access_token>`
 - **성공 응답** (`200 OK`):
   ```json
@@ -26,12 +26,13 @@ Google Drive 데이터 소스가 연결된 사용자가 `/google-drive/files/pul
         "name": "회의록.docx",
         "mime_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "modified_time": "2025-10-29T02:18:01Z",
-        "format": "pdf",
-        "pdf_path": "/storage/acme/googledrive/pdf/회의록-1Ab....pdf",
+        "format": "openxml_document",
+        "file_path": "/storage/acme/googledrive/pdf/회의록-1Ab....docx",
+        "structured_format": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
         "text_length": 12452
       }
     ],
-    "jsonl_records": [{"file_id": "1Ab...", "chunk_index": 0, "pdf_path": "/storage/..."}],
+    "jsonl_records": [{"file_id": "1Ab...", "chunk_index": 0, "file_path": "/storage/...", "structured_format": "application/vnd.openxmlformats-officedocument.wordprocessingml.document"}],
     "jsonl_text": "{...}\n{...}",
     "skipped_files": [{"file_id": "2Cd...", "reason": "다운로드 권한이 없습니다."}],
     "ingested_chunks": 12,
@@ -53,11 +54,11 @@ Google Drive 데이터 소스가 연결된 사용자가 `/google-drive/files/pul
 3. `ensure_workspace_storage`가 반환한 경로 하위에 `googledrive/pdf` 디렉터리를 구성한다.
 4. `fetch_authorized_text_files`가 Google Drive API를 호출해 변환 가능한 파일 목록을 가져오고, 각 파일에 대해 다음을 수행한다.
    - 다운로드 권한이 없거나 지원하지 않는 MIME 타입(예: HWP)은 `skipped_files`에 기록하고 로그에 남긴다.
-   - Google Docs/Sheets/Slides는 Export API로 PDF를 생성하고, Office 파일은 Google 문서 사본을 만든 뒤 PDF로 Export한다.
-   - PDF 바이트를 워크스페이스 경로(`<storage>/<workspace>/googledrive/pdf/<정규화된-파일명-<id>>.pdf`)에 저장한다.
-   - `pypdf.PdfReader`로 텍스트를 추출하고 추출 실패/빈 텍스트 상황을 로그로 남긴다.
-5. `build_records_from_files`가 PDF 경로와 포맷 정보를 포함한 JSON Lines 레코드를 생성한다.
-6. `build_documents_from_records`가 레코드를 LangChain `Document`로 변환하며 워크스페이스 메타데이터와 `pdf_path`를 주입한다.
+   - Google Docs/Sheets/Slides는 Export API로 PDF 또는 DOCX(OpenXML)로 변환하고, Office 파일은 필요 시 Google 문서 사본을 만든 뒤 동일하게 Export한다.
+   - 변환된 바이트를 워크스페이스 경로(`<storage>/<workspace>/googledrive/pdf/<정규화된-파일명-<id>>.(pdf|docx)`)에 저장한다.
+   - PDF는 `pypdf.PdfReader`로 텍스트를 추출하고, DOCX(OpenXML)는 `word/document.xml`을 추출한 뒤 XML을 평문으로 변환한다.
+5. `build_records_from_files`가 저장 경로, 포맷, OpenXML XML 문자열(`structured_text`)을 포함한 JSON Lines 레코드를 생성한다.
+6. `build_documents_from_records`가 레코드를 LangChain `Document`로 변환하며 워크스페이스 메타데이터에 `file_path`, `structured_format`, `structured_text`를 주입한다.
 7. `ChromaRAGService.replace_documents`가 기본 인덱스를 갱신하고, `collection_stats`로 페이지/벡터 수를 집계한다.
 8. `RagIndex` 및 `DataSource.synced` 메타데이터를 현재 시각으로 업데이트한 뒤 DB에 커밋한다.
 9. 응답 본문에 PDF 저장 경로, 텍스트 길이, JSONL, 스킵된 파일, 동기화 결과를 포함한다.
@@ -65,8 +66,8 @@ Google Drive 데이터 소스가 연결된 사용자가 `/google-drive/files/pul
 ---
 
 ## 5) 데이터 및 스토리지 영향
-- 워크스페이스 스토리지 내 `googledrive/pdf` 디렉터리에 PDF 파일이 생성된다.
-- `jsonl_records` 각 항목에 `pdf_path`가 포함되어 추후 추적이 가능하다.
+- 워크스페이스 스토리지 내 `googledrive/pdf` 디렉터리에 PDF 또는 DOCX(OpenXML) 파일이 생성된다.
+- `jsonl_records` 각 항목에 `file_path`, `structured_format`, `structured_text`(해당 시)이 포함되어 추후 추적이 가능하다.
 - `RagIndex`의 `storage_uri`, `object_count`, `vector_count`, `updated`가 PDF 기반 동기화 결과로 갱신된다.
 - `DataSource.synced`에 최근 동기화 시각이 저장된다.
 

--- a/backend/agents/40-stories/US-003.6-구글드라이브OpenXML서식보존.md
+++ b/backend/agents/40-stories/US-003.6-구글드라이브OpenXML서식보존.md
@@ -1,0 +1,28 @@
+# Google Drive OpenXML 서식 보존 시나리오
+
+## 1) 개요
+Google Drive 데이터 소스에서 Word 계열 문서를 동기화할 때, 문서의 OpenXML 태그를 함께 보존해 향후 동일한 서식으로 재생성할 수 있도록 한다. `/google-drive/files/pull` 호출 시 추출된 `word/document.xml`과 저장 경로가 JSONL/Document 메타데이터로 전달되어야 한다.
+
+---
+
+## 2) 선행 조건
+- 사용자는 Google Drive 데이터 소스에 연결되어 있고 액세스 토큰이 유효하다.
+- 워크스페이스 스토리지가 준비되어 있으며 `googledrive/pdf` 경로에 파일 저장이 가능하다.
+- 동기화할 파일이 Google Docs 또는 DOCX 형식으로 존재한다.
+
+---
+
+## 3) 기대 시나리오
+1. 사용자가 `/google-drive/files/pull` 엔드포인트를 호출한다.
+2. 백엔드는 대상 파일을 DOCX(OpenXML)로 내보내거나 그대로 다운로드하여 워크스페이스에 저장한다.
+3. 저장된 DOCX에서 `word/document.xml`을 추출하고 원본 XML 문자열을 `structured_text`로 보존한다.
+4. XML은 `_xml_to_plain_text` 유틸리티로 평문이 파생되어 RAG 청크의 `plain_text`/`formatted_text`로 사용된다.
+5. JSONL 각 레코드와 LangChain `Document` 메타데이터에는 `file_path`, `structured_format`, `structured_text`가 포함되어 향후 문서 재생성에 활용된다.
+6. 응답 본문 `files` 항목 역시 OpenXML 파일 여부와 저장 경로를 노출한다.
+
+---
+
+## 4) 완료 조건
+- 동기화 결과 JSONL/메타데이터에서 OpenXML XML 문자열을 확인할 수 있다.
+- RAG 검색 시 반환되는 메타데이터에 `structured_text`와 `structured_format`이 포함된다.
+- 기존 PDF 전용 동기화 플로우와 충돌 없이 작동한다.

--- a/backend/agents/50-tasks/TASK-022.4-google-drive-pdf-export.md
+++ b/backend/agents/50-tasks/TASK-022.4-google-drive-pdf-export.md
@@ -1,8 +1,8 @@
 ---
 id: TASK-0022.4
 type: task
-title: Google Drive 파일 PDF 저장 및 RAG 텍스트 추출
-description: "Google Drive에서 변환 가능한 파일을 워크스페이스에 PDF로 저장하고 텍스트를 추출해 RAG 파이프라인에 전달한다."
+title: Google Drive 파일 PDF/OpenXML 저장 및 RAG 텍스트 추출
+description: "Google Drive에서 변환 가능한 파일을 워크스페이스에 PDF 또는 OpenXML(DOCX)로 저장하고 텍스트/구조화를 수행해 RAG 파이프라인에 전달한다."
 status: done
 owner: backend
 updated: 2025-10-30
@@ -10,9 +10,9 @@ updated: 2025-10-30
 
 ## 요청 사항
 - Google Drive API에서 다운로드 가능한 문서/스프레드시트/프레젠테이션을 탐색하고, 페이지네이션을 따라가며 전체 목록을 수집한다.
-- Google Workspace 네이티브 파일은 Export API로, Office 문서는 Google 문서 사본을 생성한 뒤 PDF로 변환한다.
-- 변환된 PDF는 워크스페이스 스토리지 `<workspace>/googledrive/pdf` 경로에 파일명 정규화 규칙을 적용해 저장한다.
-- 저장된 PDF에서 텍스트를 추출하고, 청크 분할 후 JSONL 레코드 및 LangChain `Document` 메타데이터에 `pdf_path`를 포함한다.
+- Google Workspace 네이티브 파일은 Export API로, Office 문서는 Google 문서 사본을 생성한 뒤 PDF 또는 DOCX(OpenXML)로 변환한다.
+- 변환된 파일은 워크스페이스 스토리지 `<workspace>/googledrive/pdf` 경로에 파일명 정규화 규칙을 적용해 저장한다.
+- 저장된 파일에서 텍스트를 추출하고, 청크 분할 후 JSONL 레코드 및 LangChain `Document` 메타데이터에 `file_path`, `structured_format`, `structured_text`(해당 시)를 포함한다.
 - 처리 현황과 스킵된 파일, 텍스트 추출 실패 등을 로깅해 운영 가시성을 확보한다.
 
 ## 진행 기록
@@ -22,6 +22,7 @@ updated: 2025-10-30
 - 2025-10-30: `/google-drive/files/pull` 엔드포인트가 PDF 저장 경로, JSONL 레코드, 스킵 로그를 응답으로 반환하도록 연동했다.
 
 ## 결과
-- 증분 동기화 호출 시 변환된 PDF가 워크스페이스 스토리지에 축적되고, 동일한 경로 정보가 RAG 메타데이터에 포함된다.
+- 증분 동기화 호출 시 변환된 PDF/DOCX 파일이 워크스페이스 스토리지에 축적되고, 동일한 경로 및 OpenXML XML 정보가 RAG 메타데이터에 포함된다.
 - `ChromaRAGService.replace_documents`를 통해 추출 텍스트가 기본 RAG 인덱스에 적재되며, 인덱스 통계가 최신 상태로 갱신된다.
 - 스킵된 파일 리스트와 상세 이유가 API 응답과 로그에 남아 재시도 전략 수립과 오류 분석이 쉬워졌다.
+

--- a/backend/agents/50-tasks/TASK-022.6-google-drive-openxml-rag.md
+++ b/backend/agents/50-tasks/TASK-022.6-google-drive-openxml-rag.md
@@ -1,0 +1,24 @@
+---
+id: TASK-0022.6
+type: task
+title: Google Drive OpenXML 구조 텍스트 RAG 적재
+description: "Google Drive Word 계열 문서를 OpenXML XML과 함께 RAG에 보존할 수 있도록 백엔드 파이프라인을 확장한다."
+status: done
+owner: backend
+updated: 2025-11-13
+---
+
+## 요청 사항
+- DOCX 및 Google Docs 문서 동기화 시 `word/document.xml`을 추출해 RAG 메타데이터에 포함한다.
+- JSONL 레코드와 `/google-drive/files/pull` 응답에 저장 경로와 구조화 포맷 정보를 노출한다.
+- 기존 PDF 기반 처리 흐름과 호환되도록 구현한다.
+
+## 진행 기록
+- 2025-11-13: Google Drive 동기화 모듈에 OpenXML 추출 유틸리티(`_extract_docx_xml`, `_xml_to_plain_text`)를 연결하고 `GoogleDriveFile` 모델을 확장했다.
+- 2025-11-13: JSONL/Document 메타데이터에 `structured_text`, `structured_format`, `file_path` 필드를 추가했다.
+- 2025-11-13: `/google-drive/files/pull` 응답에 OpenXML 관련 정보를 반환하도록 조정하고 스토리/태스크 문서를 갱신했다.
+
+## 결과
+- 동기화된 DOCX 문서는 XML 태그가 포함된 `structured_text` 메타데이터와 함께 RAG에 적재된다.
+- RAG 검색 결과에서 `structured_format`과 `file_path`를 확인해 원문 서식을 재구성할 수 있다.
+- 기존 PDF 파일 처리 로직은 영향 없이 유지된다.


### PR DESCRIPTION
## Summary
- export Google Docs and DOCX files as OpenXML when syncing Google Drive content and persist the original XML alongside plain text
- derive plain-text chunks from the structured XML while keeping the formatted markup in document metadata for downstream RAG use

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915b8f7bb10832aa7f5aca8902aa4f5)