### PR TITLE
Add prompt-driven final answer agent

### DIFF
--- a/backend/ai_module/LANGGRAPH.md
+++ b/backend/ai_module/LANGGRAPH.md
@@ -1,0 +1,68 @@
+# LangGraph 오케스트레이션 개요
+
+`WorkspaceAgentOrchestrator`는 `langgraph`의 `StateGraph`를 사용해 검색과 문서 생성 흐름을 분기 처리합니다. 각 노드는 공통 상태(`AgentState`)를 공유하며, 비동기 노드 실행 결과를 머지해 다음 단계에서 활용합니다.
+
+## 상태와 결과 구조
+- **AgentState**: 질의어(`query`), 워크스페이스 정보(`workspace_idx`, `workspace_name`, `storage_uri`), DB 세션(`db`), 사용자 식별자(`user_idx`), 결정(`decision`), 검색 결과(`result`), 생성 컨텍스트(`retrieval`), 생성물(`generated_document`), 실행 모드(`mode`), 생성한 노션 페이지(`notion_page`), 최종 문장 다듬기 지침(`final_message_instructions`)을 포함합니다.
+- **AgentExecutionResult**: 최종 모드(`search` 또는 `generate`), 사용자 응답(`result`), 생성된 노션 페이지 ID/URL(존재 시), 의사결정, 생성된 문서를 API 계층에 반환합니다.
+
+## 노드 정의와 역할
+- **decide** (`_node_decide`)
+  - `DecisionAgent`를 호출해 사용자의 요청을 `search` 또는 `generate`로 분류하고, 생성 시 RAG 사용 여부(`use_rag`)와 지침을 수집합니다.
+- **search** (`_node_search`)
+  - `WorkspaceRAGSearchAgent.search`를 실행해 하이브리드 검색과 답변 생성을 수행하고, 모드를 `search`로 설정합니다.
+- **prepare_rag** (`_node_prepare_rag`)
+  - `WorkspaceRAGSearchAgent.retrieve_for_generation`으로 생성용 컨텍스트와 인용 정보를 수집합니다.
+- **generate** (`_node_generate`)
+  - `DocumentGenerationAgent.generate`를 호출해 RAG 컨텍스트(옵션)와 결정된 지침을 기반으로 마크다운 문서를 생성하고, 모드를 `generate`로 설정합니다.
+- **create_page** (`_node_create_page`)
+  - 생성된 문서로 노션 페이지를 만들고(`create_page_from_markdown`), 요약/URL을 포함한 사용자 응답(`SearchResult`)을 구성합니다.
+- **final_answer** (`_node_finalize`)
+  - 검색/생성 결과 초안을 `FinalAnswerAgent`의 프롬프트로 한 번 정제한 뒤, 프런트엔드로 전달할 최종 `SearchResult`를 반환합니다.
+  - `run(final_message_instructions=...)`으로 전달된 추가 지침이 있으면 최종 표현을 다듬을 때 함께 반영합니다.
+
+> **모델 분리**
+> 최종 답변 노드는 전용 Azure Chat 배포를 사용합니다. `.env`에 다음 환경 변수를 설정하세요:
+> `FINAL_ANSWER_AZURE_OPENAI_API_KEY`, `FINAL_ANSWER_AZURE_OPENAI_ENDPOINT`, `FINAL_ANSWER_AZURE_OPENAI_API_VERSION`, `FINAL_ANSWER_AZURE_OPENAI_CHAT_DEPLOYMENT`, `FINAL_ANSWER_AZURE_OPENAI_CHAT_MODEL`(옵션, 미설정 시 `deployment` 값 사용)
+
+## 그래프 연결 관계
+- **진입점**: `decide`
+- **조건 분기** (`_route_from_decision`)
+  - `search` → `search`
+  - `generate` + `use_rag=True` → `prepare_rag`
+  - `generate` + `use_rag=False` → `generate`
+  - 결정 부재 → `END`
+- **고정 엣지**
+  - `prepare_rag` → `generate`
+ - `generate` → `create_page`
+  - `search` → `final_answer`
+  - `create_page` → `final_answer`
+  - `final_answer` → `END`
+
+```mermaid
+flowchart TD
+    start([start]) --> decide{{decide}};
+    decide -->|mode == search| search[[search]];
+    decide -->|mode == generate & use_rag| prepare_rag[[prepare_rag]];
+    decide -->|mode == generate & !use_rag| generate[[generate]];
+    decide -->|no decision| end1([END]);
+
+    prepare_rag --> generate;
+    generate --> create_page[[create_page]];
+
+    search --> final_answer[[final_answer]];
+    create_page --> final_answer;
+
+    final_answer --> end2([END]);
+```
+
+## 실행 흐름 요약
+1. `run`이 초기 상태(질의, 워크스페이스/사용자 정보, DB 세션, 저장소 URI)를 세팅하고 그래프를 `ainvoke`로 실행합니다.
+2. `decide` 노드가 요청 성격과 RAG 필요 여부를 판정합니다.
+3. 검색 분기: `search` 노드는 RAG 검색·답변을 수행한 뒤 종료합니다.
+4. 생성 분기(RAG 포함):
+   - `prepare_rag`가 생성용 컨텍스트와 인용을 확보합니다.
+   - `generate`가 문서를 작성합니다.
+   - `create_page`가 노션 페이지를 생성하고 사용자 응답을 완성합니다.
+5. `final_answer`가 프롬프트 기반으로 검색/생성 결과 초안을 다듬어 최종 `SearchResult`를 구성합니다.
+6. 최종 상태의 `mode`, `result`, 노션 페이지 정보, 결정/생성 결과를 `AgentExecutionResult`로 반환합니다.

--- a/backend/ai_module/ai_config.py
+++ b/backend/ai_module/ai_config.py
@@ -33,6 +33,39 @@ def _gpt5_load_chat_config() -> Dict[str, str]:
         "deployment": deployment,
         "model": model or deployment,
     }
+
+
+def _final_answer_load_chat_config() -> Dict[str, str]:
+    """최종 답변용 Azure Chat 설정을 불러온다."""
+
+    api_key = os.getenv("FINAL_ANSWER_AZURE_OPENAI_API_KEY")
+    endpoint = os.getenv("FINAL_ANSWER_AZURE_OPENAI_ENDPOINT")
+    api_version = os.getenv("FINAL_ANSWER_AZURE_OPENAI_API_VERSION")
+    deployment = os.getenv("FINAL_ANSWER_AZURE_OPENAI_CHAT_DEPLOYMENT")
+    model = os.getenv("FINAL_ANSWER_AZURE_OPENAI_CHAT_MODEL")
+
+    missing = [
+        name
+        for name, value in [
+            ("FINAL_ANSWER_AZURE_OPENAI_API_KEY", api_key),
+            ("FINAL_ANSWER_AZURE_OPENAI_ENDPOINT", endpoint),
+            ("FINAL_ANSWER_AZURE_OPENAI_API_VERSION", api_version),
+            ("FINAL_ANSWER_AZURE_OPENAI_CHAT_DEPLOYMENT", deployment),
+        ]
+        if not value
+    ]
+    if missing:
+        raise RuntimeError(
+            "다음 Azure OpenAI 채팅 환경 변수를 설정하세요: " + ", ".join(missing)
+        )
+
+    return {
+        "api_key": api_key,
+        "endpoint": endpoint,
+        "api_version": api_version,
+        "deployment": deployment,
+        "model": model or deployment,
+    }
     
 
 def _decision_load_chat_config() -> Dict[str, str]:

--- a/backend/ai_module/final_answer.py
+++ b/backend/ai_module/final_answer.py
@@ -1,0 +1,90 @@
+"""최종 사용자 답변을 다듬는 에이전트."""
+from __future__ import annotations
+
+from typing import Literal, Optional
+
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnableSequence
+from langchain_openai import AzureChatOpenAI
+
+from .ai_config import _final_answer_load_chat_config
+
+
+class FinalAnswerAgent:
+    """검색/생성 결과 초안을 사용자-facing 문장으로 정리한다."""
+
+    def __init__(self) -> None:
+        self._prompt = ChatPromptTemplate.from_messages(
+            [
+                (
+                    "system",
+                    (
+                        "당신은 Arcana의 응답 편집기입니다."
+                        " 제공된 초안(answer_draft)만 활용해 사용자에게 전달할 최종 문장을 한국어로 다듬으세요.\n"
+                        "- 새로운 사실이나 URL을 만들지 말고, 초안에 있는 정보만 유지하세요.\n"
+                        "- 초안에 포함된 URL/인용 라인은 그대로 보존하세요.\n"
+                        "- 필요하면 문장을 더 읽기 쉽게 정리하되, 의미를 왜곡하지 마세요.\n"
+                    ),
+                ),
+                (
+                    "human",
+                    (
+                        "모드: {mode}\n"
+                        "워크스페이스: {workspace_name}\n"
+                        "사용자 질문: {question}\n"
+                        "추가 가이드: {custom_instructions}\n"
+                        "초안(answer_draft):\n{answer_draft}\n\n"
+                        "위 초안을 사용자에게 보여줄 최종 문장으로 정제하세요."
+                    ),
+                ),
+            ]
+        )
+        self._parser = StrOutputParser()
+        self._llm: Optional[AzureChatOpenAI] = None
+        self._chain: Optional[RunnableSequence] = None
+
+    def _ensure_llm(self) -> AzureChatOpenAI:
+        if self._llm is None:
+            config = _final_answer_load_chat_config()
+            self._llm = AzureChatOpenAI(
+                azure_endpoint=config["endpoint"],
+                api_key=config["api_key"],
+                api_version=config["api_version"],
+                azure_deployment=config["deployment"],
+                model=config["model"],
+                temperature=0.2,
+                max_tokens=600,
+                max_retries=3,
+            )
+        return self._llm
+
+    def _ensure_chain(self) -> RunnableSequence:
+        if self._chain is None:
+            llm = self._ensure_llm()
+            self._chain = self._prompt | llm | self._parser
+        return self._chain
+
+    async def craft_final_answer(
+        self,
+        *,
+        answer_draft: str,
+        question: str,
+        workspace_name: str,
+        mode: Literal["search", "generate"],
+        custom_instructions: Optional[str] = None,
+    ) -> str:
+        """최종 사용자 응답을 생성한다."""
+
+        chain = self._ensure_chain()
+        rendered = await chain.ainvoke(
+            {
+                "answer_draft": answer_draft,
+                "question": question,
+                "workspace_name": workspace_name,
+                "mode": mode,
+                "custom_instructions": custom_instructions or "(추가 가이드 없음)",
+            }
+        )
+        return rendered.strip()
+


### PR DESCRIPTION
## Summary
- introduce a FinalAnswerAgent that refines search/generation drafts via a dedicated prompt
- allow orchestrator callers to supply optional final_message_instructions and route final_answer through the agent
- document the new prompt-driven finalization flow in LANGGRAPH.md
- configure the final answer stage to use a dedicated Azure Chat deployment via FINAL_ANSWER_* environment variables and document the requirement

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ebbb8b42c832aad8db32bf3f039d4)