### PR TITLE
Add disconnect controls for data source list

### DIFF
--- a/frontend/my-react-app/src/components/MainDashboard.jsx
+++ b/frontend/my-react-app/src/components/MainDashboard.jsx
@@ -293,7 +293,16 @@ const SectionTitle = styled.h3`
 
 const DataSourceItem = styled(NavItem)`
   color: #A0AEC0;
-  
+  justify-content: space-between;
+  gap: 12px;
+`;
+
+const DataSourceInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+
   span {
     width: 20px;
     height: 20px;
@@ -303,6 +312,31 @@ const DataSourceItem = styled(NavItem)`
     justify-content: center;
     font-size: 12px;
     font-weight: 700;
+    flex-shrink: 0;
+  }
+`;
+
+const DisconnectButton = styled.button`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: #CBD5E0;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.05);
+    color: #F56565;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 `;
 
@@ -705,6 +739,17 @@ const providerDetails = {
   "google-drive": { name: 'Google Drive', icon: 'G', color: '#1A73E8', bg: '#E8F0FE' },
 };
 
+const getDisconnectEndpoint = (connection) => {
+  const providerKey = (connection?.type || connection?.name || '').toLowerCase();
+
+  if (providerKey === 'notion') return '/api/notion/disconnect';
+  if (providerKey === 'googledrive' || providerKey === 'google-drive' || providerKey === 'google_drive') {
+    return '/api/google-drive/disconnect';
+  }
+
+  return null;
+};
+
 const getProviderDetails = connection => {
   const providerKey = (connection?.type || connection?.name || '').toLowerCase();
   const baseDetails = providerDetails[providerKey];
@@ -791,6 +836,7 @@ function MainDashboard() {
   const [chatInput, setChatInput] = useState('');
   const [connections, setConnections] = useState([]);
   const [loadingConnections, setLoadingConnections] = useState(true);
+  const [disconnectingSource, setDisconnectingSource] = useState(null);
   const [syncing, setSyncing] = useState(false);
   const [syncMessage, setSyncMessage] = useState(null);
   const navigate = useNavigate();
@@ -1114,20 +1160,79 @@ function MainDashboard() {
     document.body.removeChild(textArea);
   };
 
+  const handleDisconnectConnection = async (event, connection) => {
+    event?.stopPropagation?.();
+
+    const details = getProviderDetails(connection);
+    const endpoint = getDisconnectEndpoint(connection);
+
+    if (!endpoint) {
+      alert('이 데이터 소스는 아직 연결 해제를 지원하지 않습니다.');
+      return;
+    }
+
+    const confirmMessage = `${details.name} 데이터 소스 연결을 끊으시겠습니까?`;
+    const shouldDisconnect = window.confirm(confirmMessage);
+    if (!shouldDisconnect) return;
+
+    const token = localStorage.getItem('accessToken');
+    if (!token) {
+      navigate('/login');
+      return;
+    }
+
+    try {
+      setDisconnectingSource(connection?.type || details.name);
+      await axios.post(endpoint, {}, {
+        headers: {
+          'Authorization': `Bearer ${token}`
+        }
+      });
+
+      await fetchConnections(token);
+    } catch (err) {
+      console.error('Failed to disconnect data source:', err);
+      const status = err?.response?.status;
+      if (status === 401 || status === 404) {
+        navigate('/login');
+        return;
+      }
+
+      const detail = err?.response?.data?.detail;
+      alert(detail ? `연결 해제에 실패했습니다: ${detail}` : '연결 해제에 실패했습니다. 잠시 후 다시 시도해주세요.');
+    } finally {
+      setDisconnectingSource(null);
+    }
+  };
+
   const renderConnectionItem = (conn) => {
     const details = getProviderDetails(conn);
-    
+    const itemKey = conn.type || details.name;
+    const isDisconnecting = disconnectingSource === itemKey;
+
     if (conn.status === 'connected' || conn.connected === true) {
       return (
-        <DataSourceItem key={conn.type || details.name}>
-          <span style={{ color: details.color, backgroundColor: details.bg }}>
-            {details.icon}
-          </span>
-          {details.name}
+        <DataSourceItem key={itemKey}>
+          <DataSourceInfo>
+            <span style={{ color: details.color, backgroundColor: details.bg }}>
+              {details.icon}
+            </span>
+            <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {details.name}
+            </span>
+          </DataSourceInfo>
+          <DisconnectButton
+            aria-label={`${details.name} 연결 끊기`}
+            title="연결 끊기"
+            onClick={(event) => handleDisconnectConnection(event, conn)}
+            disabled={isDisconnecting}
+          >
+            {isDisconnecting ? '…' : <X size={14} />}
+          </DisconnectButton>
         </DataSourceItem>
       );
     }
-    return null; 
+    return null;
   };
 
   return (

--- a/frontend/my-react-app/src/components/MainDashboard.jsx
+++ b/frontend/my-react-app/src/components/MainDashboard.jsx
@@ -303,7 +303,8 @@ const DataSourceInfo = styled.div`
   gap: 10px;
   min-width: 0;
 
-  span {
+  /* 아이콘만 스타일 */
+  > span:first-child {
     width: 20px;
     height: 20px;
     border-radius: 4px;
@@ -313,6 +314,15 @@ const DataSourceInfo = styled.div`
     font-size: 12px;
     font-weight: 700;
     flex-shrink: 0;
+  }
+
+  /* 라벨은 남은 폭을 차지하며 줄임표 */
+  > span:last-child {
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 `;
 
@@ -752,11 +762,6 @@ const getDisconnectEndpoint = (connection) => {
 
 const getProviderDetails = connection => {
   const providerKey = (connection?.type || connection?.name || '').toLowerCase();
-
-  // allow fuzzy matches so slightly malformed values (e.g. "otic" instead of "notion")
-  // still render with the intended branding
-  if (providerKey.includes('noti')) return providerDetails.notion;
-  if (providerKey.includes('google') && providerKey.includes('drive')) return providerDetails['google-drive'];
 
   const baseDetails = providerDetails[providerKey];
 

--- a/frontend/my-react-app/src/components/MainDashboard.jsx
+++ b/frontend/my-react-app/src/components/MainDashboard.jsx
@@ -752,6 +752,12 @@ const getDisconnectEndpoint = (connection) => {
 
 const getProviderDetails = connection => {
   const providerKey = (connection?.type || connection?.name || '').toLowerCase();
+
+  // allow fuzzy matches so slightly malformed values (e.g. "otic" instead of "notion")
+  // still render with the intended branding
+  if (providerKey.includes('noti')) return providerDetails.notion;
+  if (providerKey.includes('google') && providerKey.includes('drive')) return providerDetails['google-drive'];
+
   const baseDetails = providerDetails[providerKey];
 
   if (baseDetails) {


### PR DESCRIPTION
## Summary
- add disconnect buttons to connected data sources with confirmation before disconnecting
- call provider-specific disconnect endpoints and refresh the sidebar after completion
- style the data source list to accommodate the new control and disable it while processing

## Testing
- npm run build *(fails: vite binary missing because npm ci could not complete in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920388befe8832abcd8f8774d17c945)