### PR TITLE
Improve chat auto-scroll behavior

### DIFF
--- a/frontend/my-react-app/src/components/MainDashboard.jsx
+++ b/frontend/my-react-app/src/components/MainDashboard.jsx
@@ -915,6 +915,7 @@ function MainDashboard() {
 
   const [chatMessages, setChatMessages] = useState([]);
   const [isChatLoading, setIsChatLoading] = useState(false);
+  const [isAutoScrollEnabled, setIsAutoScrollEnabled] = useState(true);
   const chatContainerRef = useRef(null);
   const textareaRef = useRef(null);
   const chatRequestControllerRef = useRef(null);
@@ -1239,10 +1240,26 @@ function MainDashboard() {
   }, [handleRefreshKnowledge, shouldAutoRefresh, syncing]);
 
   useEffect(() => {
-    if (chatContainerRef.current) {
+    if (chatContainerRef.current && isAutoScrollEnabled) {
       chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight;
     }
-  }, [chatMessages, isChatLoading]);
+  }, [chatMessages, isChatLoading, isAutoScrollEnabled]);
+
+  useEffect(() => {
+    const container = chatContainerRef.current;
+    if (!container) return;
+
+    const handleScroll = () => {
+      const { scrollTop, scrollHeight, clientHeight } = container;
+      const isAtBottom = Math.abs(scrollHeight - scrollTop - clientHeight) < 10;
+      setIsAutoScrollEnabled(isAtBottom);
+    };
+
+    container.addEventListener('scroll', handleScroll);
+    return () => {
+      container.removeEventListener('scroll', handleScroll);
+    };
+  }, []);
 
   const autoResizeTextarea = (element) => {
     element.style.height = 'auto';


### PR DESCRIPTION
## Summary
- add auto-scroll state to the chat container and track user scroll position
- keep new messages pinned to the bottom only when auto-scroll is enabled
- disable auto-scrolling when the user scrolls away from the latest message and re-enable when they return to the bottom

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921672ae268832a82ab9f19856c0d4f)