### PR TITLE
Replace alert popups with inline messages

### DIFF
--- a/frontend/my-react-app/src/components/MainDashboard.jsx
+++ b/frontend/my-react-app/src/components/MainDashboard.jsx
@@ -1338,7 +1338,10 @@ function MainDashboard() {
     const endpoint = getDisconnectEndpoint(connection);
 
     if (!endpoint) {
-      alert('이 데이터 소스는 아직 연결 해제를 지원하지 않습니다.');
+      setSyncMessage({
+        variant: 'warning',
+        message: `${details.name} 데이터 소스는 아직 연결 해제를 지원하지 않습니다.`,
+      });
       return;
     }
 
@@ -1368,7 +1371,12 @@ function MainDashboard() {
       }
 
       const detail = err?.response?.data?.detail;
-      alert(detail ? `연결 해제에 실패했습니다: ${detail}` : '연결 해제에 실패했습니다. 잠시 후 다시 시도해주세요.');
+      setSyncMessage({
+        variant: 'error',
+        message: detail
+          ? `연결 해제에 실패했습니다: ${detail}`
+          : '연결 해제에 실패했습니다. 잠시 후 다시 시도해주세요.',
+      });
     } finally {
       setDisconnectingSource(null);
     }

--- a/frontend/my-react-app/src/components/RegisterPage.jsx
+++ b/frontend/my-react-app/src/components/RegisterPage.jsx
@@ -133,6 +133,18 @@ const ErrorMessage = styled.p`
   margin: 0 0 16px 0;
 `;
 
+const SuccessMessage = styled.p`
+  font-size: 14px;
+  color: #2E7D32;
+  background-color: #E8F5E9;
+  border: 1px solid #A5D6A7;
+  border-radius: 8px;
+  padding: 12px;
+  width: 100%;
+  text-align: center;
+  margin: 0 0 16px 0;
+`;
+
 const Footer = styled.footer`
   margin-top: 30px;
   font-size: 12px;
@@ -163,6 +175,7 @@ function RegisterPage() {
   });
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [successMessage, setSuccessMessage] = useState(null);
   
   const navigate = useNavigate();
 
@@ -178,6 +191,7 @@ function RegisterPage() {
     e.preventDefault();
     setLoading(true);
     setError(null);
+    setSuccessMessage(null);
 
     const payload = { ...formData };
     if (payload.type === 'personal') {
@@ -192,11 +206,11 @@ function RegisterPage() {
 
     try {
       const response = await apiClient.post(apiUrl, payload);
-      
+
       console.log('Register Success:', response);
-      alert('회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.');
-      navigate('/login');
-      
+      setSuccessMessage('회원가입이 완료되었습니다. 로그인 페이지로 이동합니다.');
+      setTimeout(() => navigate('/login'), 1000);
+
     } catch (err) {
       if (err.response && err.response.data && err.response.data.detail) {
         setError(err.response.data.detail);
@@ -218,6 +232,7 @@ function RegisterPage() {
 
       <Title>회원가입</Title>
 
+      {successMessage && <SuccessMessage>{successMessage}</SuccessMessage>}
       {error && <ErrorMessage>{error}</ErrorMessage>}
 
       <Form onSubmit={handleSubmit}>

--- a/frontend/notionurl.html
+++ b/frontend/notionurl.html
@@ -8,6 +8,10 @@
     body { font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial; margin: 24px; }
     input, button { font-size: 16px; padding: 8px; }
     #log { white-space: pre-wrap; background: #f6f8fa; padding: 12px; border-radius: 8px; }
+    #message { margin-top: 12px; padding: 12px; border-radius: 8px; font-weight: 600; display: none; }
+    #message.success { background: #e8f5e9; color: #2e7d32; border: 1px solid #a5d6a7; }
+    #message.error { background: #fff5f5; color: #b71c1c; border: 1px solid #ffcdd2; }
+    #message.info { background: #e3f2fd; color: #0d47a1; border: 1px solid #90caf9; }
   </style>
 </head>
 <body>
@@ -17,6 +21,8 @@
   <input id="token" type="text" placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." style="width: 100%; max-width: 720px;" />
   <div style="height:12px"></div>
   <button id="start">연동 시작</button>
+
+  <div id="message" aria-live="polite"></div>
 
   <h3>로그</h3>
   <div id="log"></div>
@@ -29,10 +35,18 @@
       el.textContent += (msg + "\n");
     };
 
+    const showMessage = (msg, type = 'info') => {
+      const el = document.getElementById('message');
+      el.textContent = msg;
+      el.className = '';
+      el.classList.add(type);
+      el.style.display = 'block';
+    };
+
     document.getElementById('start').addEventListener('click', async () => {
       const token = document.getElementById('token').value.trim();
       if (!token) {
-        alert('JWT 토큰을 입력하세요.');
+        showMessage('JWT 토큰을 입력하세요.', 'error');
         return;
       }
       log("요청: POST /notion/connect");
@@ -59,10 +73,11 @@
         const data = await res.json();
         const authorizeUrl = data.authorize_url;
         log("authorize_url 받음 → 브라우저 네비게이션으로 이동");
-        alert(authorizeUrl)
+        showMessage('인증 페이지로 이동합니다.', 'info');
         window.location.href = authorizeUrl; // ← 이게 핵심 (CORS 우회)
       } catch (e) {
         log("네트워크 오류: " + (e && e.message ? e.message : e));
+        showMessage('네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.', 'error');
       }
     });
   </script>


### PR DESCRIPTION
## Summary
- replace registration success alert with an inline success banner and brief delay before redirect
- show data source disconnect issues through the dashboard status bar instead of browser alerts
- add inline status messaging to the Notion connection test page in place of alerts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69217114bb04832a9f4c3b83357c5f22)