### PR TITLE
Add custom disconnect confirmation and tidy login UI

### DIFF
--- a/frontend/my-react-app/src/components/LoginPage.jsx
+++ b/frontend/my-react-app/src/components/LoginPage.jsx
@@ -38,13 +38,15 @@ const Title = styled.h2`
   font-weight: 700;
   color: #000;
   margin-bottom: 25px;
-  align-self: flex-start;
+  align-self: center;
+  text-align: center;
 `;
 
 const Form = styled.form`
   display: flex;
   flex-direction: column;
   width: 100%;
+  margin-bottom: 16px;
 `;
 
 const Label = styled.label`
@@ -99,32 +101,9 @@ const Button = styled.button`
     css`
       background-color: #6200EE;
       color: white;
-      
+
       &:hover {
         background-color: #5100C4;
-      }
-    `}
-
-  ${(props) =>
-    props.$social === 'kakao' &&
-    css`
-      background-color: #FEE500;
-      color: #3C1E1E;
-      
-      &:hover {
-        background-color: #F0D900;
-      }
-    `}
-
-  ${(props) =>
-    props.$social === 'google' &&
-    css`
-      background-color: #FFFFFF;
-      color: #444;
-      border: 1px solid #DADCE0;
-      
-      &:hover {
-        background-color: #F8F9FA;
       }
     `}
   
@@ -155,35 +134,11 @@ const SignUpLink = styled(Link)`
   font-size: 14px;
   color: #555;
   text-decoration: none;
-  margin-top: 8px;
-  
+  margin-top: 12px;
+  text-align: center;
+
   &:hover {
     text-decoration: underline;
-  }
-`;
-
-const Separator = styled.div`
-  display: flex;
-  align-items: center;
-  text-align: center;
-  color: #AAA;
-  width: 100%;
-  margin: 24px 0;
-  font-size: 13px;
-
-  &::before,
-  &::after {
-    content: '';
-    flex: 1;
-    border-bottom: 1px solid #E0E0E0;
-  }
-
-  &::before {
-    margin-right: 12px;
-  }
-
-  &::after {
-    margin-left: 12px;
   }
 `;
 
@@ -276,17 +231,6 @@ function LoginPage() {
         아직 계정이 없으신가요? 회원가입하러 가기
       </SignUpLink>
 
-      <Separator>또는</Separator>
-
-      <Button $social="kakao" disabled={loading}>
-        {/* 아이콘 영역 (추후 svg/img 태그) */}
-        카카오톡으로 3초만에 로그인
-      </Button>
-      
-      <Button $social="google" disabled={loading}>
-        {/* 아이콘 영역 (추후 svg/img 태그) */}
-        구글ID 로그인으로 회원가입
-      </Button>
     </Container>
   );
 }


### PR DESCRIPTION
## Summary
- replace the data source disconnect alert with an inline confirmation bar that includes explicit cancel/confirm actions and status feedback
- remove Kakao/Google social login options and center the remaining login elements for a balanced layout

## Testing
- `npm run lint` *(fails: missing @eslint/js because npm registry access is restricted in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69219ef6fba4832ab9839a9c79f03938)